### PR TITLE
Fix app_settings import

### DIFF
--- a/rest_auth/views.py
+++ b/rest_auth/views.py
@@ -11,7 +11,7 @@ from rest_framework.authentication import SessionAuthentication, \
 from rest_framework.authtoken.models import Token
 from rest_framework.generics import RetrieveUpdateAPIView
 
-from app_settings import (TokenSerializer, UserDetailsSerializer,
+from .app_settings import (TokenSerializer, UserDetailsSerializer,
     LoginSerializer, PasswordResetSerializer, PasswordResetConfirmSerializer,
     PasswordChangeSerializer)
 


### PR DESCRIPTION
The url paths:

```
    url(r'^rest-auth/', include('rest_auth.urls')),
    url(r'^rest-auth/registration/', include('rest_auth.registration.urls')),
```

Weren't working for me, I kept getting an ImportError `No module named 'app_settings'`.
This fixes that issue for me on Win7 x64, Python 3.4, Django 1.7
