### PR TITLE
Mark email as read only for user details

### DIFF
--- a/rest_auth/serializers.py
+++ b/rest_auth/serializers.py
@@ -46,6 +46,7 @@ class UserDetailsSerializer(serializers.ModelSerializer):
     class Meta:
         model = get_user_model()
         fields = ('username', 'email', 'first_name', 'last_name')
+        read_only_fields = ('email', )
 
 
 class PasswordResetSerializer(serializers.Serializer):


### PR DESCRIPTION
We should not allow users to change email directly via PUT/PATCH in /rest-auth/user/. This will break allauth email handling.