### PR TITLE
change PasswordResetConfirmSerializer setpasswordform exception from token invalid  value error to form validation error

### DIFF
--- a/rest_auth/serializers.py
+++ b/rest_auth/serializers.py
@@ -110,8 +110,7 @@ class PasswordResetConfirmSerializer(serializers.Serializer):
         self.set_password_form = self.set_password_form_class(user=self.user,
             data=attrs)
         if not self.set_password_form.is_valid():
-            raise ValidationError({'token': ['Invalid value']})
-
+	    raise serializers.ValidationError(self.set_password_form.errors)
         if not default_token_generator.check_token(self.user, attrs['token']):
             raise ValidationError({'token': ['Invalid value']})
 


### PR DESCRIPTION
There are two validations in this seralizer one for tokens and one for form validation.

Can't see form validation errors for password fields,  instead we get token invalid value error.(for both token and form validation)

so I changed the token validation error to form validation error in form validation part.

