### PR TITLE
Django 1.8 fixes

### DIFF
--- a/rest_auth/utils.py
+++ b/rest_auth/utils.py
@@ -1,6 +1,6 @@
 from six import string_types
 import sys
-if sys.version_info < (2, 6):
+if sys.version_info < (2, 7):
     from django.utils.importlib import import_module
 else:
     from importlib import import_module

--- a/rest_auth/utils.py
+++ b/rest_auth/utils.py
@@ -1,5 +1,9 @@
 from six import string_types
-from django.utils.importlib import import_module
+import sys
+if sys.version_info < (2, 6):
+    from django.utils.importlib import import_module
+else:
+    from importlib import import_module
 
 
 def import_callable(path_or_callable):


### PR DESCRIPTION
This PR removes a warning due to the usage of `django.utils.importlib` which is [deprecated](https://docs.djangoproject.com/en/dev/releases/1.7/#django-utils-dictconfig-django-utils-importlib).
*Includes backward compatibility for Django 1.5 & 1.6 + Python 2.6.*

Also please consider bumping the module version as Django 1.8 is the current stable branch now.