### PR TITLE
move SocialAccount population to the separate method in the SocialLoginSerializer

### DIFF
--- a/rest_auth/registration/serializers.py
+++ b/rest_auth/registration/serializers.py
@@ -13,7 +13,7 @@ class SocialLoginSerializer(serializers.Serializer):
             request = request._request
         return request
 
-    def get_social_account(self, adapter, app, token, response):
+    def get_social_login(self, adapter, app, token, response):
         """
 
         :param adapter: allauth.socialaccount Adapter subclass. Usually OAuthAdapter or Auth2Adapter
@@ -47,7 +47,7 @@ class SocialLoginSerializer(serializers.Serializer):
         token.app = app
 
         try:
-            login = self.get_social_account(adapter, app, token, access_token)
+            login = self.get_social_login(adapter, app, token, access_token)
             complete_social_login(request, login)
         except HTTPError:
             raise serializers.ValidationError('Incorrect value')

--- a/rest_auth/registration/serializers.py
+++ b/rest_auth/registration/serializers.py
@@ -5,36 +5,49 @@ from allauth.socialaccount.helpers import complete_social_login
 
 
 class SocialLoginSerializer(serializers.Serializer):
-
     access_token = serializers.CharField(required=True)
+
+    def _get_request(self):
+        request = self.context.get('request')
+        if not isinstance(request, HttpRequest):
+            request = request._request
+        return request
+
+    def get_social_account(self, adapter, app, token, response):
+        """
+
+        :param adapter: allauth.socialaccount Adapter subclass. Usually OAuthAdapter or Auth2Adapter
+        :param app: `allauth.socialaccount.SocialApp` instance
+        :param token: `allauth.socialaccount.SocialToken` instance
+        :param response: Provider's response for OAuth1. Not used in the
+        :return: :return: A populated instance of the `allauth.socialaccount.SocialLogin` instance
+        """
+        request = self._get_request()
+        social_login = adapter.complete_login(request, app, token, response=response)
+        social_login.token = token
+        return social_login
 
     def validate(self, attrs):
         access_token = attrs.get('access_token')
         view = self.context.get('view')
-        request = self.context.get('request')
-        if not isinstance(request, HttpRequest):
-            request = request._request
+        request = self._get_request()
 
         if not view:
             raise serializers.ValidationError(
                 'View is not defined, pass it as a context variable'
             )
 
-        self.adapter_class = getattr(view, 'adapter_class', None)
-
-        if not self.adapter_class:
+        adapter_class = getattr(view, 'adapter_class', None)
+        if not adapter_class:
             raise serializers.ValidationError('Define adapter_class in view')
 
-        self.adapter = self.adapter_class()
-        app = self.adapter.get_provider().get_app(request)
-        token = self.adapter.parse_token({'access_token': access_token})
+        adapter = adapter_class()
+        app = adapter.get_provider().get_app(request)
+        token = adapter.parse_token({'access_token': access_token})
         token.app = app
 
         try:
-            login = self.adapter.complete_login(request, app, token,
-                                                response=access_token)
-
-            login.token = token
+            login = self.get_social_account(adapter, app, token, access_token)
             complete_social_login(request, login)
         except HTTPError:
             raise serializers.ValidationError('Incorrect value')


### PR DESCRIPTION
It makes easier to get the correct signup for custom user models, because application can subclass SocialLoginSeriaLizer and add required fields to the instance.

Should allow easy solving of #78 