### PR TITLE
Replaced request.DATA with request.data for compatibility with DRF 3.2

### DIFF
--- a/rest_auth/registration/views.py
+++ b/rest_auth/registration/views.py
@@ -37,7 +37,7 @@ class Register(APIView, SignupView):
 
     def post(self, request, *args, **kwargs):
         self.initial = {}
-        self.request.POST = self.request.DATA.copy()
+        self.request.POST = self.request.data.copy()
         form_class = self.get_form_class()
         self.form = self.get_form(form_class)
         if self.form.is_valid():
@@ -63,7 +63,7 @@ class VerifyEmail(APIView, ConfirmEmailView):
         return Response({}, status=status.HTTP_405_METHOD_NOT_ALLOWED)
 
     def post(self, request, *args, **kwargs):
-        self.kwargs['key'] = self.request.DATA.get('key', '')
+        self.kwargs['key'] = self.request.data.get('key', '')
         confirmation = self.get_object()
         confirmation.confirm(self.request)
         return Response({'message': 'ok'}, status=status.HTTP_200_OK)

--- a/rest_auth/views.py
+++ b/rest_auth/views.py
@@ -50,7 +50,7 @@ class Login(GenericAPIView):
         )
 
     def post(self, request, *args, **kwargs):
-        self.serializer = self.get_serializer(data=self.request.DATA)
+        self.serializer = self.get_serializer(data=self.request.data)
         if not self.serializer.is_valid():
             return self.get_error_response()
         self.login()
@@ -110,8 +110,8 @@ class PasswordReset(GenericAPIView):
     permission_classes = (AllowAny,)
 
     def post(self, request, *args, **kwargs):
-        # Create a serializer with request.DATA
-        serializer = self.get_serializer(data=request.DATA)
+        # Create a serializer with request.data
+        serializer = self.get_serializer(data=request.data)
 
         if not serializer.is_valid():
             return Response(serializer.errors,
@@ -138,7 +138,7 @@ class PasswordResetConfirm(GenericAPIView):
     permission_classes = (AllowAny,)
 
     def post(self, request):
-        serializer = self.get_serializer(data=request.DATA)
+        serializer = self.get_serializer(data=request.data)
         if not serializer.is_valid():
             return Response(
                 serializer.errors, status=status.HTTP_400_BAD_REQUEST
@@ -160,7 +160,7 @@ class PasswordChange(GenericAPIView):
     permission_classes = (IsAuthenticated,)
 
     def post(self, request):
-        serializer = self.get_serializer(data=request.DATA)
+        serializer = self.get_serializer(data=request.data)
         if not serializer.is_valid():
             return Response(
                 serializer.errors, status=status.HTTP_400_BAD_REQUEST


### PR DESCRIPTION
In the latest version of DRF 3.2, `request.DATA` has been deprecated in favor of `request.data`. I've made this minor change to make it work with one of my projects.