### PR TITLE
Adds check for optional deps in INSTALLED_APPS

### DIFF
--- a/rest_auth/registration/serializers.py
+++ b/rest_auth/registration/serializers.py
@@ -4,7 +4,10 @@ from requests.exceptions import HTTPError
 # Import is needed only if we are using social login, in which
 # case the allauth.socialaccount will be declared
 try:
+    apps.get_app_config('allauth.socialaccount')
     from allauth.socialaccount.helpers import complete_social_login
+except LookupError:
+    pass
 except ImportError:
     pass
 


### PR DESCRIPTION
Previously the serializers.py file relied solely on the presence of
allauth.socialaccount in the PYTHON_PATH to determine if its use was
required. This adds another check in the Django INSTALLED_APPS for the
allauth.socialaccount app, and then continues with the import if the app
has been added.

Closes #71 