### PR TITLE
Add support for keeping the user logged in after password change (Django 1.7+)

### DIFF
--- a/docs/api_endpoints.rst
+++ b/docs/api_endpoints.rst
@@ -30,9 +30,10 @@ Basic
     - new_password1
     - new_password2
     - old_password
-    
-    
+
+
     .. note:: ``OLD_PASSWORD_FIELD_ENABLED = True`` to use old_password.
+    .. note:: ``LOGOUT_ON_PASSWORD_CHANGE = False`` to keep the user logged in after password change
 
 - /rest-auth/user/ (GET)
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -34,3 +34,5 @@ Configuration
 
 
 - **OLD_PASSWORD_FIELD_ENABLED** - set it to True if you want to have old password verification on password change enpoint (default: False)
+
+- **LOGOUT_ON_PASSWORD_CHANGE** - set to False if you want to keep the current user logged in after a password change

--- a/rest_auth/serializers.py
+++ b/rest_auth/serializers.py
@@ -216,5 +216,5 @@ class PasswordChangeSerializer(serializers.Serializer):
 
     def save(self):
         self.set_password_form.save()
-        if self.logout_on_password_change:
+        if not self.logout_on_password_change:
             update_session_auth_hash(self.request, self.user)

--- a/rest_auth/serializers.py
+++ b/rest_auth/serializers.py
@@ -12,6 +12,7 @@ from django.utils.translation import ugettext_lazy as _
 from rest_framework import serializers, exceptions
 from rest_framework.authtoken.models import Token
 from rest_framework.exceptions import ValidationError
+from django.contrib.auth import update_session_auth_hash
 
 
 class LoginSerializer(serializers.Serializer):
@@ -182,6 +183,9 @@ class PasswordChangeSerializer(serializers.Serializer):
         self.old_password_field_enabled = getattr(
             settings, 'OLD_PASSWORD_FIELD_ENABLED', False
         )
+        self.logout_on_password_change = getattr(
+            settings, 'LOGOUT_ON_PASSWORD_CHANGE', False
+        )
         super(PasswordChangeSerializer, self).__init__(*args, **kwargs)
 
         if not self.old_password_field_enabled:
@@ -212,3 +216,5 @@ class PasswordChangeSerializer(serializers.Serializer):
 
     def save(self):
         self.set_password_form.save()
+        if self.logout_on_password_change:
+            update_session_auth_hash(self.request, self.user)


### PR DESCRIPTION
Fixes #111

For Django 1.7+ Allauth invalidates the session of the current logged in user when they change their password. In order to avoid this `user_session_auth_hash(request,user)` must be used. More details can be found here https://docs.djangoproject.com/en/1.8/topics/auth/default/#session-invalidation-on-password-change

What I've done:
 - Created new flag called `LOGOUT_ON_PASSWORD_CHANGE`
 - When the above flag is `False`, `user_session_auth_hash` is called
