### PR TITLE
Alter a statement to make it python3 compatible

### DIFF
--- a/rest_auth/tests.py
+++ b/rest_auth/tests.py
@@ -49,7 +49,7 @@ class BaseAPITestCase(object):
 
         self.response = request_func(*args, **kwargs)
         is_json = bool(
-            filter(lambda x: 'json' in x, self.response._headers['content-type']))
+            [x for x in self.response._headers['content-type'] if 'json' in x])
         if is_json and self.response.content:
             self.response.json = json.loads(self.response.content)
         else:


### PR DESCRIPTION
- In python 3, filter returns an iterator instead of a list
- Thus bool(filter(...)) always evaluated to true on python3
- Convert the filter to a list comprehension to ensure it evaluated as
  expected on python 3