### PR TITLE
Bypass AssertionErrors on nested Hyperlinked fields

### DIFF
--- a/rest_auth/registration/views.py
+++ b/rest_auth/registration/views.py
@@ -62,7 +62,8 @@ class RegisterView(APIView, SignupView):
 
     def get_response(self):
         # serializer = self.user_serializer_class(instance=self.user)
-        serializer = self.serializer_class(instance=self.token)
+        serializer = self.serializer_class(instance=self.token,
+                context={'request': self.request})
         return Response(serializer.data, status=status.HTTP_201_CREATED)
 
     def get_response_with_errors(self):


### PR DESCRIPTION
Send request as context data to the UserDetailsSerializer class, when
signing up. This way nested Hyperlinked serializer fields can be
correctly resolved.

The problem occurs, when setting up a custom USER_DETAILS_SERIALIZER class, which contains a nested model with hyperlinked serializer fields (for example HyperlinkedIdentityField). These need a context to be able to build the API links correctly.

Adding the request as the context fixes the AssertionError, which occurs in the described situation without the context. The error message suggests this fix, which is now introduced to the appropriate location. :)