### PR TITLE
Include user and token details in login/register response

### DIFF
--- a/rest_auth/registration/views.py
+++ b/rest_auth/registration/views.py
@@ -9,7 +9,7 @@ from allauth.account.views import SignupView, ConfirmEmailView
 from allauth.account.utils import complete_signup
 from allauth.account import app_settings
 
-from rest_auth.app_settings import TokenSerializer, UserDetailsSerializer
+from rest_auth.app_settings import UserDetailsSerializer
 from rest_auth.registration.serializers import SocialLoginSerializer
 from rest_auth.views import LoginView
 
@@ -22,13 +22,12 @@ class RegisterView(APIView, SignupView):
     Calls allauth complete_signup method
 
     Accept the following POST parameters: username, email, password
-    Return the REST Framework Token Object's key.
+    Return user details and DRF's token key.
     """
 
     permission_classes = (AllowAny,)
     allowed_methods = ('POST', 'OPTIONS', 'HEAD')
     token_model = Token
-    serializer_class = TokenSerializer
     response_serializer = UserDetailsSerializer
 
     def get(self, *args, **kwargs):

--- a/rest_auth/registration/views.py
+++ b/rest_auth/registration/views.py
@@ -9,7 +9,7 @@ from allauth.account.views import SignupView, ConfirmEmailView
 from allauth.account.utils import complete_signup
 from allauth.account import app_settings
 
-from rest_auth.app_settings import TokenSerializer
+from rest_auth.app_settings import TokenSerializer, UserDetailsSerializer
 from rest_auth.registration.serializers import SocialLoginSerializer
 from rest_auth.views import LoginView
 
@@ -29,6 +29,7 @@ class RegisterView(APIView, SignupView):
     allowed_methods = ('POST', 'OPTIONS', 'HEAD')
     token_model = Token
     serializer_class = TokenSerializer
+    response_serializer = UserDetailsSerializer
 
     def get(self, *args, **kwargs):
         return Response({}, status=status.HTTP_405_METHOD_NOT_ALLOWED)
@@ -65,9 +66,10 @@ class RegisterView(APIView, SignupView):
             return self.get_response_with_errors()
 
     def get_response(self):
-        # serializer = self.user_serializer_class(instance=self.user)
-        serializer = self.serializer_class(instance=self.token,
-                                           context={'request': self.request})
+        serializer = self.response_serializer(
+            instance=self.user,
+            context={'request': self.request}
+        )
         return Response(serializer.data, status=status.HTTP_201_CREATED)
 
     def get_response_with_errors(self):

--- a/rest_auth/serializers.py
+++ b/rest_auth/serializers.py
@@ -89,18 +89,18 @@ class TokenSerializer(serializers.ModelSerializer):
 
 
 class UserDetailsSerializer(serializers.ModelSerializer):
-
     """
     User model w/o password
     """
+    token = serializers.ReadOnlyField(source='auth_token.key')
+
     class Meta:
         model = get_user_model()
-        fields = ('username', 'email', 'first_name', 'last_name')
+        fields = ('username', 'email', 'first_name', 'last_name', 'token',)
         read_only_fields = ('email', )
 
 
 class PasswordResetSerializer(serializers.Serializer):
-
     """
     Serializer for requesting a password reset e-mail.
     """

--- a/rest_auth/tests.py
+++ b/rest_auth/tests.py
@@ -184,8 +184,8 @@ class APITestCase1(TestCase, BaseAPITestCase):
         user = get_user_model().objects.create_user(self.USERNAME, '', self.PASS)
 
         self.post(self.login_url, data=payload, status_code=200)
-        self.assertEqual('key' in self.response.json.keys(), True)
-        self.token = self.response.json['key']
+        self.assertEqual('token' in self.response.json.keys(), True)
+        self.token = self.response.json['token']
 
         self.post(self.password_change_url, status_code=400)
 
@@ -211,7 +211,7 @@ class APITestCase1(TestCase, BaseAPITestCase):
         }
         get_user_model().objects.create_user(self.USERNAME, '', self.PASS)
         self.post(self.login_url, data=login_payload, status_code=200)
-        self.token = self.response.json['key']
+        self.token = self.response.json['token']
 
         new_password_payload = {
             "new_password1": "new_person",
@@ -252,7 +252,7 @@ class APITestCase1(TestCase, BaseAPITestCase):
         }
         get_user_model().objects.create_user(self.USERNAME, '', self.PASS)
         self.post(self.login_url, data=login_payload, status_code=200)
-        self.token = self.response.json['key']
+        self.token = self.response.json['token']
 
         new_password_payload = {
             "old_password": "%s!" % self.PASS,  # wrong password
@@ -345,7 +345,7 @@ class APITestCase1(TestCase, BaseAPITestCase):
             "password": self.PASS
         }
         self.post(self.login_url, data=payload, status_code=200)
-        self.token = self.response.json['key']
+        self.token = self.response.json['token']
         self.get(self.user_url, status_code=200)
 
         self.patch(self.user_url, data=self.BASIC_USER_DATA, status_code=200)
@@ -479,12 +479,12 @@ class TestSocialAuth(TestCase, BaseAPITestCase):
         }
 
         self.post(self.fb_login_url, data=payload, status_code=200)
-        self.assertIn('key', self.response.json.keys())
+        self.assertIn('token', self.response.json.keys())
         self.assertEqual(get_user_model().objects.all().count(), users_count + 1)
 
         # make sure that second request will not create a new user
         self.post(self.fb_login_url, data=payload, status_code=200)
-        self.assertIn('key', self.response.json.keys())
+        self.assertIn('token', self.response.json.keys())
         self.assertEqual(get_user_model().objects.all().count(), users_count + 1)
 
     @responses.activate
@@ -531,4 +531,4 @@ class TestSocialAuth(TestCase, BaseAPITestCase):
         }
 
         self.post(self.fb_login_url, data=payload, status_code=200)
-        self.assertIn('key', self.response.json.keys())
+        self.assertIn('token', self.response.json.keys())

--- a/rest_auth/views.py
+++ b/rest_auth/views.py
@@ -10,7 +10,7 @@ from rest_framework.authtoken.models import Token
 from rest_framework.generics import RetrieveUpdateAPIView
 
 from .app_settings import (
-    TokenSerializer, UserDetailsSerializer, LoginSerializer,
+    UserDetailsSerializer, LoginSerializer,
     PasswordResetSerializer, PasswordResetConfirmSerializer,
     PasswordChangeSerializer
 )

--- a/rest_auth/views.py
+++ b/rest_auth/views.py
@@ -25,7 +25,7 @@ class LoginView(GenericAPIView):
     in Django session framework
 
     Accept the following POST parameters: username, password
-    Return the REST Framework Token Object's key.
+    Return user details and DRF's token key.
     """
     permission_classes = (AllowAny,)
     serializer_class = LoginSerializer
@@ -88,7 +88,7 @@ class UserDetailsView(RetrieveUpdateAPIView):
     Accepts the following POST parameters:
         Required: token
         Optional: email, first_name, last_name and UserProfile fields
-    Returns the updated UserProfile and/or User object.
+    Returns DRF's token key with updated UserProfile and/or User object.
     """
     serializer_class = UserDetailsSerializer
     permission_classes = (IsAuthenticated,)

--- a/rest_auth/views.py
+++ b/rest_auth/views.py
@@ -30,7 +30,7 @@ class LoginView(GenericAPIView):
     permission_classes = (AllowAny,)
     serializer_class = LoginSerializer
     token_model = Token
-    response_serializer = TokenSerializer
+    response_serializer = UserDetailsSerializer
 
     def login(self):
         self.user = self.serializer.validated_data['user']
@@ -41,7 +41,7 @@ class LoginView(GenericAPIView):
 
     def get_response(self):
         return Response(
-            self.response_serializer(self.token).data, status=status.HTTP_200_OK
+            self.response_serializer(self.user).data, status=status.HTTP_200_OK
         )
 
     def get_error_response(self):


### PR DESCRIPTION
Include token key (read-only) inside `UserDetailsSerializer` and use this serializer as response for register and login endpoints.
 
Resolves #74. 