### PR TITLE
raise_exception=True for views

### DIFF
--- a/rest_auth/views.py
+++ b/rest_auth/views.py
@@ -44,15 +44,9 @@ class LoginView(GenericAPIView):
             self.response_serializer(self.token).data, status=status.HTTP_200_OK
         )
 
-    def get_error_response(self):
-        return Response(
-            self.serializer.errors, status=status.HTTP_400_BAD_REQUEST
-        )
-
     def post(self, request, *args, **kwargs):
         self.serializer = self.get_serializer(data=self.request.data)
-        if not self.serializer.is_valid():
-            return self.get_error_response()
+        self.serializer.is_valid(raise_exception=True)
         self.login()
         return self.get_response()
 
@@ -112,10 +106,8 @@ class PasswordResetView(GenericAPIView):
     def post(self, request, *args, **kwargs):
         # Create a serializer with request.data
         serializer = self.get_serializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
 
-        if not serializer.is_valid():
-            return Response(serializer.errors,
-                            status=status.HTTP_400_BAD_REQUEST)
         serializer.save()
         # Return the success message with OK HTTP status
         return Response(
@@ -139,10 +131,7 @@ class PasswordResetConfirmView(GenericAPIView):
 
     def post(self, request):
         serializer = self.get_serializer(data=request.data)
-        if not serializer.is_valid():
-            return Response(
-                serializer.errors, status=status.HTTP_400_BAD_REQUEST
-            )
+        serializer.is_valid(raise_exception=True)
         serializer.save()
         return Response({"success": "Password has been reset with the new password."})
 
@@ -161,9 +150,6 @@ class PasswordChangeView(GenericAPIView):
 
     def post(self, request):
         serializer = self.get_serializer(data=request.data)
-        if not serializer.is_valid():
-            return Response(
-                serializer.errors, status=status.HTTP_400_BAD_REQUEST
-            )
+        serializer.is_valid(raise_exception=True)
         serializer.save()
         return Response({"success": "New password has been saved."})


### PR DESCRIPTION
As was [announced at Django REST framework 3.0](http://www.django-rest-framework.org/topics/3.0-announcement/#using-is_validraise_exceptiontrue), using ```serializer.is_valid(raise_exception=True)``` may help to remove error response handling from view code. Also it is useful when somebody uses custom error hadnling, for example, to make reponses with validation errors more consistence with other error responses