### PR TITLE
Use the new urlpatterns syntax for Django 1.9.

### DIFF
--- a/rest_auth/registration/urls.py
+++ b/rest_auth/registration/urls.py
@@ -1,10 +1,9 @@
 from django.views.generic import TemplateView
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from .views import RegisterView, VerifyEmailView
 
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     url(r'^$', RegisterView.as_view(), name='rest_register'),
     url(r'^verify-email/$', VerifyEmailView.as_view(), name='rest_verify_email'),
 
@@ -21,4 +20,4 @@ urlpatterns = patterns(
     # djang-allauth https://github.com/pennersr/django-allauth/blob/master/allauth/account/views.py#L190
     url(r'^account-confirm-email/(?P<key>\w+)/$', TemplateView.as_view(),
         name='account_confirm_email'),
-)
+]

--- a/rest_auth/urls.py
+++ b/rest_auth/urls.py
@@ -1,12 +1,11 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from rest_auth.views import (
     LoginView, LogoutView, UserDetailsView, PasswordChangeView,
     PasswordResetView, PasswordResetConfirmView
 )
 
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     # URLs that do not require a session or valid token
     url(r'^password/reset/$', PasswordResetView.as_view(),
         name='rest_password_reset'),
@@ -18,4 +17,4 @@ urlpatterns = patterns(
     url(r'^user/$', UserDetailsView.as_view(), name='rest_user_details'),
     url(r'^password/change/$', PasswordChangeView.as_view(),
         name='rest_password_change'),
-)
+]


### PR DESCRIPTION
Because:

* Using `rest_auth` in Django 1.9 shows `DeprecationWarning`s related to the  removal of `django.conf.urls.patterns()` in Django 1.10.

This commit:

* Replaces the `urlpatterns` syntax with a list of `django.conf.urls.url()` instances.