### PR TITLE
Make email in password reset serializer Case unsensetive

### DIFF
--- a/rest_auth/serializers.py
+++ b/rest_auth/serializers.py
@@ -115,7 +115,7 @@ class PasswordResetSerializer(serializers.Serializer):
         if not self.reset_form.is_valid():
             raise serializers.ValidationError(_('Error'))
 
-        if not UserModel.objects.filter(email=value).exists():
+        if not UserModel.objects.filter(email__iexact=value).exists():
             raise serializers.ValidationError(_('Invalid e-mail address'))
 
         return value


### PR DESCRIPTION
if user input correct email but in wrong case.
For example use Capital letters instead Lover case or mix them, he will get error. But really DB exist his email.