### PR TITLE
Update demo.rst

### DIFF
--- a/docs/demo.rst
+++ b/docs/demo.rst
@@ -11,7 +11,7 @@ Do these steps to make it running (ideally in virtualenv).
     git clone https://github.com/Tivix/django-rest-auth.git
     cd django-rest-auth/demo/
     pip install -r requirements.pip
-    python manage.py syncdb --settings=demo.settings --noinput
+    python manage.py migrate --settings=demo.settings --noinput
     python manage.py runserver --settings=demo.settings
 
 Now, go to ``http://127.0.0.1:8000/`` in your browser.


### PR DESCRIPTION
With requirements file of django >= 1.7.0, change command of `syncdb` to `migrate` (`syncdb` is deprecated) in demo setup instructions.