### PR TITLE
#131: Do not raise 400 when resetting password for non-existing account

### DIFF
--- a/rest_auth/serializers.py
+++ b/rest_auth/serializers.py
@@ -115,9 +115,6 @@ class PasswordResetSerializer(serializers.Serializer):
         if not self.reset_form.is_valid():
             raise serializers.ValidationError(_('Error'))
 
-        if not UserModel.objects.filter(email__iexact=value).exists():
-            raise serializers.ValidationError(_('Invalid e-mail address'))
-
         return value
 
     def save(self):

--- a/rest_auth/tests/test_api.py
+++ b/rest_auth/tests/test_api.py
@@ -234,12 +234,15 @@ class APITestCase1(TestCase, BaseAPITestCase):
         self.assertEqual(len(mail.outbox), mail_count + 1)
 
     def test_password_reset_with_invalid_email(self):
+        """
+        Invalid email should not raise error, as this would leak users
+        """
         get_user_model().objects.create_user(self.USERNAME, self.EMAIL, self.PASS)
 
         # call password reset
         mail_count = len(mail.outbox)
         payload = {'email': 'nonexisting@email.com'}
-        self.post(self.password_reset_url, data=payload, status_code=400)
+        self.post(self.password_reset_url, data=payload, status_code=200)
         self.assertEqual(len(mail.outbox), mail_count)
 
     def test_user_details(self):


### PR DESCRIPTION
- Do not raises validation error if email doesn't exist
- Update unit test