### PR TITLE
#86: Add missing dependencies to setup.py

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -38,7 +38,7 @@ You're good to go now!
 Registration (optional)
 -----------------------
 
-1. If you want to enable standard registration process you will need to install ``django-allauth`` - see this doc for installation http://django-allauth.readthedocs.org/en/latest/installation.html.
+1. If you want to enable standard registration process you will need to install ``django-allauth`` by using ``pip install django-rest-auth[extras]`` or ``pip install django-rest-auth[with_social]``.
 
 2. Add ``allauth``, ``allauth.account`` and ``rest_auth.registration`` apps to INSTALLED_APPS in your django settings.py:
 

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,13 @@ setup(
         'djangorestframework>=3.1.0',
         'six>=1.9.0',
     ],
+    extras_require={
+        'with_social': ['django-allauth>=0.24.1'],
+    },
+    tests_require=[
+        'responses>=0.5.0',
+        'django-allauth>=0.24.1',
+    ],
     test_suite='runtests.runtests',
     include_package_data=True,
     # cmdclass={},


### PR DESCRIPTION
- Add django-allauth as an extra, and update documentation
- Ensure django-allauth and responses are present when running tests