### PR TITLE
Added a Serializer for Twitter oauth

### DIFF
--- a/docs/api_endpoints.rst
+++ b/docs/api_endpoints.rst
@@ -70,3 +70,8 @@ Basing on example from installation section :doc:`Installation </installation>`
 
     - access_token
     - code
+
+- /rest-auth/twitter/ (POST)
+
+    - access_token
+    - token_secret

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -126,4 +126,12 @@ Using ``django-allauth``, ``django-rest-auth`` provides helpful class for creati
         serializer_class = TwitterLoginSerializer
         adapter_class = TwitterOAuthAdapter
 
+7. Create url for TwitterLogin view:
+
+.. code-block:: python
+
+    urlpatterns += pattern('',
+        ...,
+        url(r'^rest-auth/twitter/$', TwitterLogin.as_view(), name='twitter_login')
+    )
 .. note:: Starting from v0.21.0, django-allauth has dropped support for context processors. Check out http://django-allauth.readthedocs.org/en/latest/changelog.html#from-0-21-0 for more details.

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -85,6 +85,8 @@ Using ``django-allauth``, ``django-rest-auth`` provides helpful class for creati
         ...,
         'allauth.socialaccount',
         'allauth.socialaccount.providers.facebook',
+        'allauth.socialaccount.providers.twitter',
+
     )
 
 2. Add Social Application in django admin panel
@@ -107,5 +109,21 @@ Using ``django-allauth``, ``django-rest-auth`` provides helpful class for creati
         ...,
         url(r'^rest-auth/facebook/$', FacebookLogin.as_view(), name='fb_login')
     )
+
+5. If you are using Twitter for your social authentication, it is a bit different from 
+   Facebook since Twitter uses OAuth 1.0. 
+
+
+6. Create new view as a subclass of ``rest_auth.views.LoginView`` with ``TwitterOAuthAdapter`` adapter and  ``TwitterLoginSerializer`` as an attribute:
+
+.. code-block:: python
+
+    from allauth.socialaccount.providers.twitter.views import TwitterOAuthAdapter
+    from rest_auth.views import LoginView
+    from rest_auth.social_serializers import TwitterLoginSerializer
+
+    class TwitterLogin(LoginView):
+        serializer_class = TwitterLoginSerializer
+        adapter_class = TwitterOAuthAdapter
 
 .. note:: Starting from v0.21.0, django-allauth has dropped support for context processors. Check out http://django-allauth.readthedocs.org/en/latest/changelog.html#from-0-21-0 for more details.

--- a/rest_auth/social_serializers.py
+++ b/rest_auth/social_serializers.py
@@ -1,0 +1,78 @@
+from django.http import HttpRequest
+from rest_framework import serializers
+from requests.exceptions import HTTPError
+# Import is needed only if we are using social login, in which
+# case the allauth.socialaccount will be declared
+try:
+    from allauth.socialaccount.helpers import complete_social_login
+except ImportError:
+    pass
+
+from allauth.socialaccount.models import SocialToken
+
+
+class TwitterLoginSerializer(serializers.Serializer):
+    access_token = serializers.CharField(required=True)
+    token_secret = serializers.CharField(required=True)
+
+    def _get_request(self):
+        request = self.context.get('request')
+        if not isinstance(request, HttpRequest):
+            request = request._request
+        return request
+
+    def get_social_login(self, adapter, app, token, response):
+        """
+
+        :param adapter: allauth.socialaccount Adapter subclass. Usually OAuthAdapter or Auth2Adapter
+        :param app: `allauth.socialaccount.SocialApp` instance
+        :param token: `allauth.socialaccount.SocialToken` instance
+        :param response: Provider's response for OAuth1. Not used in the
+        :return: :return: A populated instance of the `allauth.socialaccount.SocialLoginView` instance
+        """
+        request = self._get_request()
+        social_login = adapter.complete_login(request, app, token, response=response)
+        social_login.token = token
+        return social_login
+
+    def validate(self, attrs):
+        view = self.context.get('view')
+        request = self._get_request()
+
+        if not view:
+            raise serializers.ValidationError(
+                'View is not defined, pass it as a context variable'
+            )
+
+        adapter_class = getattr(view, 'adapter_class', None)
+        if not adapter_class:
+            raise serializers.ValidationError('Define adapter_class in view')
+
+        adapter = adapter_class()
+        app = adapter.get_provider().get_app(request)
+
+        if('access_token' in attrs) and ('token_secret' in attrs):
+            access_token = attrs.get('access_token')
+            token_secret = attrs.get('token_secret')
+        else:
+            raise serializers.ValidationError('Incorrect input. access_token and token_secret are required.')
+
+        request.session['oauth_api.twitter.com_access_token'] = {
+                'oauth_token': access_token,
+                'oauth_token_secret': token_secret,
+        }
+        token = SocialToken(token=access_token, token_secret=token_secret)
+        token.app = app
+
+        try:
+            login = self.get_social_login(adapter, app, token, access_token)
+            complete_social_login(request, login)
+        except HTTPError:
+            raise serializers.ValidationError('Incorrect value')
+
+        if not login.is_existing:
+            login.lookup()
+            login.save(request, connect=True)
+        attrs['user'] = login.account.user
+
+        return attrs


### PR DESCRIPTION
Added a serializer for twitter OAuth to work. If you are not using this it will cause an error ('TwitterOAuthAdapter' object has no attribute 'parse_token'). It happens because method parse_token() is implemented in OAuth2Adapter, but Twitter uses OAuth 1.0, so TwitterOAuthAdapter inherits from OAuthAdapter, which doesn't have parse_token() method. Example usage is given below:

class TwitterLogin(LoginView):
    serializer_class = TwitterLoginSerializer
    adapter_class = TwitterOAuthAdapter