### PR TITLE
Adds logout to API endpoints demo project 

### DIFF
--- a/demo/demo/urls.py
+++ b/demo/demo/urls.py
@@ -11,6 +11,8 @@ urlpatterns = [
         name='email-verification'),
     url(r'^login/$', TemplateView.as_view(template_name="login.html"),
         name='login'),
+    url(r'^logout/$', TemplateView.as_view(template_name="logout.html"),
+        name='logout'),
     url(r'^password-reset/$',
         TemplateView.as_view(template_name="password_reset.html"),
         name='password-reset'),

--- a/demo/templates/base.html
+++ b/demo/templates/base.html
@@ -40,6 +40,7 @@
                 <li class="divider"></li>
                 <!-- these pages require user token -->
                 <li><a href="{% url 'user-details' %}">User details</a></li>
+                <li><a href="{% url 'logout' %}">Logout</a></li>
                 <li><a href="{% url 'password-change' %}">Password change</a></li>
             </ul>
           </li>

--- a/demo/templates/fragments/logout_form.html
+++ b/demo/templates/fragments/logout_form.html
@@ -1,0 +1,20 @@
+{% block content %}
+
+  <form class="form-horizontal ajax-post" role="form" action="{% url 'rest_logout' %}">{% csrf_token %}
+    <div class="form-group">
+      <label for="token" class="col-sm-2 control-label">User Token</label>
+      <div class="col-sm-4">
+        <input name="token" type="text" class="form-control" id="token" placeholder="Token">
+        <p class="help-block">Token received after login</p>
+      </div>
+    </div>
+
+  <div class="form-group">
+    <div class="col-sm-offset-2 col-sm-10">
+      <button type="submit" class="btn btn-default">Login</button>
+    </div>
+  </div>
+
+  <div class="form-group api-response"></div>
+  </form>
+{% endblock %}

--- a/demo/templates/logout.html
+++ b/demo/templates/logout.html
@@ -1,0 +1,8 @@
+{% extends "base.html" %}
+
+{% block content %}
+  <div class="row">
+    <h3>Logout</h3><hr/>
+    {% include "fragments/logout_form.html" %}
+  </div>
+{% endblock %}

--- a/docs/api_endpoints.rst
+++ b/docs/api_endpoints.rst
@@ -13,6 +13,8 @@ Basic
 
 - /rest-auth/logout/ (POST)
 
+    - token
+
 - /rest-auth/password/reset/ (POST)
 
     - email


### PR DESCRIPTION
When I stumbled upon this project I realized that the logout ability wasn't directly listed in the API endpoints for the demo project. It is however in the localhost:8000/rest_auth/logout URL. I figured it was desirable to have the logout explicitly shown in the demo project as the login API endpoint is in the demo and is also accessible via the localhost:8000/rest_auth/login URL.

Anyway, all of the tests still pass and it seems to be working. I tested it manually and it worked as well. Just cloned the repo, installed the necessary packages via the requirements file, and launched the server from the command line and it is all there.