### PR TITLE
Add context to response_serializer in LoginView

### DIFF
--- a/rest_auth/views.py
+++ b/rest_auth/views.py
@@ -41,7 +41,7 @@ class LoginView(GenericAPIView):
 
     def get_response(self):
         return Response(
-            self.response_serializer(self.token).data, status=status.HTTP_200_OK
+            self.response_serializer(self.token, context=self.get_serializer_context()).data, status=status.HTTP_200_OK
         )
 
     def post(self, request, *args, **kwargs):


### PR DESCRIPTION
When context is missing, FileField cannot return absolute urls, that made inconsistency when used absolute urls everywhere else. serializer_class got it injected by inherited APIView, while custom serializer that is defined here didn't. This commit fixes it.