### PR TITLE
Typo in the documentation

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -29,7 +29,7 @@ Configuration
             ...
         }
 
-- **REST_AUTH_REGISTRATION_SERIALIZERS**
+- **REST_AUTH_REGISTER_SERIALIZERS**
 
     You can define your custom serializers for registration endpoint.
     Possible key values:


### PR DESCRIPTION
Source Code Ref: https://github.com/Tivix/django-rest-auth/blob/master/rest_auth/registration/app_settings.py

Documentation Ref: https://django-rest-auth.readthedocs.org/en/latest/configuration.html