### PR TITLE
Change the variable name in the doc

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -29,7 +29,7 @@ Configuration
             ...
         }
 
-- **REST_AUTH_REGISTRATION_SERIALIZERS**
+- **REST_AUTH_REGISTER_SERIALIZERS**
 
     You can define your custom serializers for registration endpoint.
     Possible key values:


### PR DESCRIPTION
You can see in this [line](https://github.com/Tivix/django-rest-auth/blob/334a29c4d976d826d8d19123611e6184656016e9/rest_auth/registration/app_settings.py#L8), that the documentation is wrong.