### PR TITLE
Capture OAuthError in TwitterLoginSerializer

### DIFF
--- a/rest_auth/registration/serializers.py
+++ b/rest_auth/registration/serializers.py
@@ -15,12 +15,8 @@ from rest_framework import serializers
 from requests.exceptions import HTTPError
 # Import is needed only if we are using social login, in which
 # case the allauth.socialaccount will be declared
-
 if 'allauth.socialaccount' in settings.INSTALLED_APPS:
-    try:
-        from allauth.socialaccount.helpers import complete_social_login
-    except ImportError:
-        pass
+    from allauth.socialaccount.helpers import complete_social_login
 
 
 class SocialLoginSerializer(serializers.Serializer):

--- a/rest_auth/social_serializers.py
+++ b/rest_auth/social_serializers.py
@@ -1,12 +1,12 @@
 from django.conf import settings
 from django.http import HttpRequest
 from rest_framework import serializers
-from requests.exceptions import HTTPError
 # Import is needed only if we are using social login, in which
 # case the allauth.socialaccount will be declared
 if 'allauth.socialaccount' in settings.INSTALLED_APPS:
     from allauth.socialaccount.helpers import complete_social_login
     from allauth.socialaccount.models import SocialToken
+    from allauth.socialaccount.providers.oauth.client import OAuthError
 
 
 class TwitterLoginSerializer(serializers.Serializer):
@@ -65,8 +65,8 @@ class TwitterLoginSerializer(serializers.Serializer):
         try:
             login = self.get_social_login(adapter, app, token, access_token)
             complete_social_login(request, login)
-        except HTTPError:
-            raise serializers.ValidationError('Incorrect value')
+        except OAuthError as e:
+            raise serializers.ValidationError(str(e))
 
         if not login.is_existing:
             login.lookup()

--- a/rest_auth/social_serializers.py
+++ b/rest_auth/social_serializers.py
@@ -1,14 +1,12 @@
+from django.conf import settings
 from django.http import HttpRequest
 from rest_framework import serializers
 from requests.exceptions import HTTPError
 # Import is needed only if we are using social login, in which
 # case the allauth.socialaccount will be declared
-try:
+if 'allauth.socialaccount' in settings.INSTALLED_APPS:
     from allauth.socialaccount.helpers import complete_social_login
-except ImportError:
-    pass
-
-from allauth.socialaccount.models import SocialToken
+    from allauth.socialaccount.models import SocialToken
 
 
 class TwitterLoginSerializer(serializers.Serializer):


### PR DESCRIPTION
The `TwitterLoginSerializer` introduced in #154 uses OAuth 1.0 and the oauth.client raises [OAuthError](https://github.com/pennersr/django-allauth/blob/45e3900/allauth/socialaccount/providers/oauth/client.py#L33) and not `HTTPError`