### PR TITLE
Fix social-adatper tests for allauth>=0.25.0

### DIFF
--- a/rest_auth/registration/serializers.py
+++ b/rest_auth/registration/serializers.py
@@ -60,7 +60,7 @@ class SocialLoginSerializer(serializers.Serializer):
         if not adapter_class:
             raise serializers.ValidationError(_('Define adapter_class in view'))
 
-        adapter = adapter_class()
+        adapter = adapter_class(request)
         app = adapter.get_provider().get_app(request)
 
         # More info on code vs access_token

--- a/setup.py
+++ b/setup.py
@@ -33,11 +33,11 @@ setup(
         'six>=1.9.0',
     ],
     extras_require={
-        'with_social': ['django-allauth>=0.24.1'],
+        'with_social': ['django-allauth>=0.25.0'],
     },
     tests_require=[
         'responses>=0.5.0',
-        'django-allauth>=0.24.1',
+        'django-allauth>=0.25.0',
     ],
     test_suite='runtests.runtests',
     include_package_data=True,


### PR DESCRIPTION
See https://github.com/pennersr/django-allauth/commit/742d114abf57917d69fbdfd9babf7fd806ddba44 for more details.

This unfortunately requires bumping up the version to 0.25.0, not sure if we want to do that though but it seems 0.25.0 doesn't have any backwards incompatible changes so I think it'll be fine.