### PR TITLE
'detail' keyword in success response messages

### DIFF
--- a/rest_auth/registration/views.py
+++ b/rest_auth/registration/views.py
@@ -77,7 +77,7 @@ class VerifyEmailView(APIView, ConfirmEmailView):
         self.kwargs['key'] = serializer.validated_data['key']
         confirmation = self.get_object()
         confirmation.confirm(self.request)
-        return Response({'message': _('ok')}, status=status.HTTP_200_OK)
+        return Response({'detail': _('ok')}, status=status.HTTP_200_OK)
 
 
 class SocialLoginView(LoginView):

--- a/rest_auth/views.py
+++ b/rest_auth/views.py
@@ -108,7 +108,7 @@ class LogoutView(APIView):
 
         logout(request)
 
-        return Response({"success": _("Successfully logged out.")},
+        return Response({"detail": _("Successfully logged out.")},
                         status=status.HTTP_200_OK)
 
 
@@ -149,7 +149,7 @@ class PasswordResetView(GenericAPIView):
         serializer.save()
         # Return the success message with OK HTTP status
         return Response(
-            {"success": _("Password reset e-mail has been sent.")},
+            {"detail": _("Password reset e-mail has been sent.")},
             status=status.HTTP_200_OK
         )
 
@@ -170,7 +170,7 @@ class PasswordResetConfirmView(GenericAPIView):
         serializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         serializer.save()
-        return Response({"success": _("Password has been reset with the new password.")})
+        return Response({"detail": _("Password has been reset with the new password.")})
 
 
 class PasswordChangeView(GenericAPIView):
@@ -188,4 +188,4 @@ class PasswordChangeView(GenericAPIView):
         serializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         serializer.save()
-        return Response({"success": _("New password has been saved.")})
+        return Response({"detail": _("New password has been saved.")})


### PR DESCRIPTION
I've seen that django-rest-auth is using 2 keywords on responses with status code HTTP_200_OK. 
In registration.views is used the keyword 'message', while in views is used the keyword 'success'.

I suggest to use the keyword 'detail' as in django-rest-framework, such that in the server we won't have different keywords for different apps.
