### PR TITLE
allows registration throttle control

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -49,3 +49,20 @@ Configuration
 - **OLD_PASSWORD_FIELD_ENABLED** - set it to True if you want to have old password verification on password change enpoint (default: False)
 
 - **LOGOUT_ON_PASSWORD_CHANGE** - set to False if you want to keep the current user logged in after a password change
+
+
+Throttling
+=============
+
+You may specify custom throttling for ``rest_auth.register.views.RegisterView`` by specifying DRF settings:
+
+    .. code-block:: python
+
+        REST_FRAMEWORK = {
+            'DEFAULT_THROTTLE_RATES': {
+                'anon': '6/m',
+                'register_view':'1/h',
+            },
+        }
+    
+

--- a/rest_auth/registration/views.py
+++ b/rest_auth/registration/views.py
@@ -28,6 +28,7 @@ class RegisterView(CreateAPIView):
     serializer_class = RegisterSerializer
     permission_classes = (AllowAny, )
     token_model = TokenModel
+    throttle_scope = 'register_view'
 
     def get_response_data(self, user):
         if allauth_settings.EMAIL_VERIFICATION == \


### PR DESCRIPTION
allow registration throttle control using settings:

```python
REST_FRAMEWORK = {
    'DEFAULT_THROTTLE_RATES': {
        'anon': '6/m',
        'register_view':'1/h',
    },
}
```