### PR TITLE
Make VerifyEmailView viewable in rest framework API browser

### DIFF
--- a/rest_auth/registration/views.py
+++ b/rest_auth/registration/views.py
@@ -1,7 +1,7 @@
 from django.utils.translation import ugettext_lazy as _
 from django.conf import settings
 
-from rest_framework.views import APIView
+from rest_framework.generics import GenericAPIView
 from rest_framework.response import Response
 from rest_framework.permissions import AllowAny
 from rest_framework.generics import CreateAPIView
@@ -65,16 +65,16 @@ class RegisterView(CreateAPIView):
         return user
 
 
-class VerifyEmailView(APIView, ConfirmEmailView):
-
+class VerifyEmailView(GenericAPIView):
+    serializer_class = VerifyEmailSerializer
     permission_classes = (AllowAny,)
-    allowed_methods = ('POST', 'OPTIONS', 'HEAD')
 
     def post(self, request, *args, **kwargs):
-        serializer = VerifyEmailSerializer(data=request.data)
+        serializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)
-        self.kwargs['key'] = serializer.validated_data['key']
-        confirmation = self.get_object()
+        view = ConfirmEmailView()
+        view.kwargs = {'key': serializer.validated_data['key']}
+        confirmation = view.get_object()
         confirmation.confirm(self.request)
         return Response({'message': _('ok')}, status=status.HTTP_200_OK)
 


### PR DESCRIPTION
The `VerifyEmailView` extends (next to `APIView`) from `ConfirmEmailView` (allauth), but only to use the `self.get_object()` method. 

The `VerifyEmailView` thus has a `get` method from `ConfirmEmailView`, however the GET request will fail because the `ConfirmEmailView` get method expects to have the key in the path and thus being passed as kwarg, so currently there is a not working GET request method handler!

I like to see all rest auth views in the rest framework API browser, to see which methods are supported and to see which fields are required.

That's why I suggest to extend from `GenericAPIView` and to move the dependency to `ConfirmEmailView` into the post method, so that using `ConfirmEmailView` is really just an implementation detail, nothing more.

I am using `GenericAPIView` instead of just `APIView`, because metadata about the accepted fields is only shown if there is a `get_serializer` method.
