### PR TITLE
Return all serializer field values in RegisterSerializer#get_cleaned_data

### DIFF
--- a/rest_auth/registration/serializers.py
+++ b/rest_auth/registration/serializers.py
@@ -150,11 +150,11 @@ class RegisterSerializer(serializers.Serializer):
         pass
 
     def get_cleaned_data(self):
-        return {
-            'username': self.validated_data.get('username', ''),
-            'password1': self.validated_data.get('password1', ''),
-            'email': self.validated_data.get('email', '')
-        }
+        data = self.validated_data
+        data.setdefault('username', '')
+        data.setdefault('password1', '')
+        data.setdefault('email', '')
+        return data
 
     def save(self, request):
         adapter = get_adapter()


### PR DESCRIPTION
`RegisterSerializer#get_cleaned_data` returns statically the fields `username`, `password1` and `email` from `self.validated_data`.

That means that all subclasses of `RegisterSerializer` have to override this method as soon as they add other fields to the new serializer.

Would be nice, if adding new fields to the serializer is all there is to do.

Tried to add a new test, but it seems that REST_AUTH settings can't be overridden:

```python
class CustomRegisterSerializer(RegisterSerializer):
    first_name = serializers.CharField(required=False, max_length=255, allow_blank=True)
    last_name = serializers.CharField(required=False, max_length=255, allow_blank=True)

...

    @override_settings(
        REST_AUTH_REGISTER_SERIALIZERS={
            'REGISTER_SERIALIZER': 'rest_auth.tests.test_api.CustomRegisterSerializer',
        }
    )
    def test_registration_with_name(self):
        self.post(self.register_url, data=self.REGISTRATION_DATA_WITH_NAME, status_code=201)

        new_user = get_user_model().objects.latest('id')

        self.assertEqual(new_user.first_name, self.REGISTRATION_DATA_WITH_NAME['first_name'])
        self.assertEqual(new_user.last_name, self.REGISTRATION_DATA_WITH_NAME['last_name'])
```