### PR TITLE
Added djangorestframework-jwt as test requirement, and typo

### DIFF
--- a/rest_auth/tests/test_api.py
+++ b/rest_auth/tests/test_api.py
@@ -459,7 +459,7 @@ class APITestCase1(TestCase, BaseAPITestCase):
         email_confirmation = new_user.emailaddress_set.get(email=self.EMAIL)\
             .emailconfirmation_set.order_by('-created')[0]
         self.post(
-            self.veirfy_email_url,
+            self.verify_email_url,
             data={"key": email_confirmation.key},
             status_code=status.HTTP_200_OK
         )

--- a/rest_auth/tests/test_base.py
+++ b/rest_auth/tests/test_base.py
@@ -97,7 +97,7 @@ class BaseAPITestCase(object):
         self.register_url = reverse('rest_register')
         self.password_reset_url = reverse('rest_password_reset')
         self.user_url = reverse('rest_user_details')
-        self.veirfy_email_url = reverse('rest_verify_email')
+        self.verify_email_url = reverse('rest_verify_email')
         self.fb_login_url = reverse('fb_login')
         self.tw_login_url = reverse('tw_login')
         self.tw_login_no_view_url = reverse('tw_login_no_view')

--- a/rest_auth/tests/test_social.py
+++ b/rest_auth/tests/test_social.py
@@ -263,7 +263,7 @@ class TestSocialAuth(TestCase, BaseAPITestCase):
         email_confirmation = new_user.emailaddress_set.get(email=self.EMAIL)\
             .emailconfirmation_set.order_by('-created')[0]
         self.post(
-            self.veirfy_email_url,
+            self.verify_email_url,
             data={"key": email_confirmation.key},
             status_code=status.HTTP_200_OK
         )

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ setup(
     tests_require=[
         'responses>=0.5.0',
         'django-allauth>=0.25.0',
+        'djangorestframework-jwt>=1.9.0',
     ],
     test_suite='runtests.runtests',
     include_package_data=True,


### PR DESCRIPTION
```$ python setup.py test``` was unable to run without djangorestframework-jwt.  
Also quick typo fix.