### PR TITLE
Custom registration permissions

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,0 +1,3 @@
+--editable .
+responses>=0.5.0
+djangorestframework-jwt

--- a/rest_auth/registration/app_settings.py
+++ b/rest_auth/registration/app_settings.py
@@ -1,5 +1,6 @@
 from django.conf import settings
 
+from rest_framework.permissions import AllowAny
 from rest_auth.registration.serializers import (
     RegisterSerializer as DefaultRegisterSerializer)
 from ..utils import import_callable
@@ -9,3 +10,10 @@ serializers = getattr(settings, 'REST_AUTH_REGISTER_SERIALIZERS', {})
 
 RegisterSerializer = import_callable(
     serializers.get('REGISTER_SERIALIZER', DefaultRegisterSerializer))
+
+
+def register_permission_classes():
+    permission_classes = [AllowAny, ]
+    for klass in  getattr(settings, 'REST_AUTH_REGISTER_PERMISSION_CLASSES', tuple()):
+        permission_classes.append(import_callable(klass))
+    return tuple(permission_classes)

--- a/rest_auth/registration/views.py
+++ b/rest_auth/registration/views.py
@@ -22,7 +22,7 @@ from rest_auth.registration.serializers import (SocialLoginSerializer,
                                                 VerifyEmailSerializer)
 from rest_auth.utils import jwt_encode
 from rest_auth.views import LoginView
-from .app_settings import RegisterSerializer
+from .app_settings import RegisterSerializer, register_permission_classes
 
 sensitive_post_parameters_m = method_decorator(
     sensitive_post_parameters('password1', 'password2')
@@ -31,7 +31,7 @@ sensitive_post_parameters_m = method_decorator(
 
 class RegisterView(CreateAPIView):
     serializer_class = RegisterSerializer
-    permission_classes = (AllowAny, )
+    permission_classes = register_permission_classes()
     token_model = TokenModel
 
     @sensitive_post_parameters_m

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ setup(
         'Django>=1.8.0',
         'djangorestframework>=3.1.0',
         'six>=1.9.0',
+        'django-allauth>=0.25.0',
     ],
     extras_require={
         'with_social': ['django-allauth>=0.25.0'],


### PR DESCRIPTION
Hi there,

This PR allows users to provide custom permission classes for the `registration` view. To do this add the following to your settings module:

```
REST_AUTH_REGISTER_PERMISSION_CLASSES = (
    'my.apps.permissions.CustomPermissionClass',
)
```

Outside of the functionality described above, I made a few convenience changes for developers:

* Added `django-allauth` to `setup.py` requirements ... I believe this should be here? Let me know if i'm mistaken.
* Added a `dev-requirements.txt` file so developers can immediately get all the dependencies and run the tests:

    ```
    pip install -r dev-requirements.py
    python runtests.py
    ```

I'm also noticing there isn't any developer specific documentation. I'd be happy to make a section in the `docs/` which describes how to get up and running and running the tests!