### PR TITLE
Pass context to user defined USER_DETAILS_SERIALIZER

### DIFF
--- a/rest_auth/serializers.py
+++ b/rest_auth/serializers.py
@@ -146,7 +146,7 @@ class JWTSerializer(serializers.Serializer):
         JWTUserDetailsSerializer = import_callable(
             rest_auth_serializers.get('USER_DETAILS_SERIALIZER', UserDetailsSerializer)
         )
-        user_data = JWTUserDetailsSerializer(obj['user']).data
+        user_data = JWTUserDetailsSerializer(obj['user'], context=self.context).data
         return user_data
 
 


### PR DESCRIPTION
I'm passing a context to my USER_DETAILS_SERIALIZER and just upgraded from 0.9.0 to 0.9.1 and noticed an error is thrown.

A pretty straightforward fix I'd say. Would love to see it tagged and released as soon as you review this.