### PR TITLE
Add option return user details on login

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -48,7 +48,7 @@ Configuration
 
 - **REST_USE_JWT** - Enable JWT Authentication instead of Token/Session based. This is built on top of django-rest-framework-jwt http://getblimp.github.io/django-rest-framework-jwt/, which must also be installed. (default: False)
 
-- **REST_USE_TOKEN** - Set to False if you want get USER_DETAILS_SERIALIZER instead any tokens, that can be useful if you use session auth backend (default: True)
+- **REST_USE_TOKEN** - Set to False if you want get USER_DETAILS_SERIALIZER instead any tokens, that can be useful if you use **just** session auth backend (default: True)
 
 - **OLD_PASSWORD_FIELD_ENABLED** - set it to True if you want to have old password verification on password change enpoint (default: False)
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -48,6 +48,8 @@ Configuration
 
 - **REST_USE_JWT** - Enable JWT Authentication instead of Token/Session based. This is built on top of django-rest-framework-jwt http://getblimp.github.io/django-rest-framework-jwt/, which must also be installed. (default: False)
 
+- **REST_USE_TOKEN** - Set to False if you want get USER_DETAILS_SERIALIZER instead any tokens, that can be useful if you use session auth backend (default: True)
+
 - **OLD_PASSWORD_FIELD_ENABLED** - set it to True if you want to have old password verification on password change enpoint (default: False)
 
 - **LOGOUT_ON_PASSWORD_CHANGE** - set to False if you want to keep the current user logged in after a password change

--- a/rest_auth/tests/test_api.py
+++ b/rest_auth/tests/test_api.py
@@ -196,6 +196,22 @@ class APITestCase1(TestCase, BaseAPITestCase):
         # bring back allauth
         settings.INSTALLED_APPS.append('allauth')
 
+    @override_settings(REST_USE_TOKEN=False)
+    def test_login_api_return_user_information(self):
+            get_user_model().objects.create_user(
+                username=self.USERNAME, password=self.PASS,
+            )
+
+            payload = {
+                'username': self.USERNAME,
+                'password': self.PASS
+            }
+            response = self.client.post(self.login_url, payload)
+            self.assertEqual(response.status_code, 200)
+
+            self.assertEqual(response.json()['username'], self.USERNAME)
+            self.assertEqual(response.json()['last_name'], "")
+
     def test_password_change(self):
         login_payload = {
             "username": self.USERNAME,

--- a/rest_auth/views.py
+++ b/rest_auth/views.py
@@ -54,8 +54,10 @@ class LoginView(GenericAPIView):
     def get_response_serializer(self):
         if getattr(settings, 'REST_USE_JWT', False):
             response_serializer = JWTSerializer
-        else:
+        elif getattr(settings, 'REST_USE_TOKEN', True):
             response_serializer = TokenSerializer
+        else:
+            response_serializer = UserDetailsSerializer
         return response_serializer
 
     def login(self):
@@ -63,7 +65,7 @@ class LoginView(GenericAPIView):
 
         if getattr(settings, 'REST_USE_JWT', False):
             self.token = jwt_encode(self.user)
-        else:
+        elif getattr(settings, 'REST_USE_TOKEN', True):
             self.token = create_token(self.token_model, self.user,
                                       self.serializer)
 
@@ -80,8 +82,11 @@ class LoginView(GenericAPIView):
             }
             serializer = serializer_class(instance=data,
                                           context={'request': self.request})
-        else:
+        elif getattr(settings, 'REST_USE_TOKEN', True):
             serializer = serializer_class(instance=self.token,
+                                          context={'request': self.request})
+        else:
+            serializer = serializer_class(instance=self.user,
                                           context={'request': self.request})
 
         return Response(serializer.data, status=status.HTTP_200_OK)


### PR DESCRIPTION
I'm finished few projects where token from login view is useless, because we use session auth for SPA and oAuth2 for mobile applications(https://django-oauth-toolkit.readthedocs.io/en/latest/). 
I'm though this PR can be useful for people who want make more elegant auth/get_user_data module in their SPA app. Without this update they will must get user data in 2 steps: login, get_user.