### PR TITLE
return user object from upstream method invocation

### DIFF
--- a/rest_auth/serializers.py
+++ b/rest_auth/serializers.py
@@ -220,7 +220,7 @@ class PasswordResetConfirmSerializer(serializers.Serializer):
         return attrs
 
     def save(self):
-        self.set_password_form.save()
+        return self.set_password_form.save()
 
 
 class PasswordChangeSerializer(serializers.Serializer):


### PR DESCRIPTION
Since the upstream method ``django.contrib.auth.forms.SetPasswordForm.save()`` returns the User object, it would be beneficial, if that would be bypassed by the method ``PasswordResetConfirmSerializer.save()``