### PR TITLE
Added rest_auth to MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,3 +2,4 @@ include AUTHORS
 include LICENSE
 include MANIFEST.in
 include README.md
+graft rest_auth


### PR DESCRIPTION
rest_auth was not added to MANIFEST.in, thus, the locale folder was missing from package on install via pip