### PR TITLE
Pass request in the context when initializing `LoginSerializer`

### DIFF
--- a/rest_auth/views.py
+++ b/rest_auth/views.py
@@ -88,7 +88,7 @@ class LoginView(GenericAPIView):
 
     def post(self, request, *args, **kwargs):
         self.request = request
-        self.serializer = self.get_serializer(data=self.request.data)
+        self.serializer = self.get_serializer(data=self.request.data, context={'request': request})
         self.serializer.is_valid(raise_exception=True)
 
         self.login()


### PR DESCRIPTION
As mentioned in the issue: https://github.com/Tivix/django-rest-auth/issues/340 , this PR passes the request in the context.