### PR TITLE
Prevent logout GET from getting documented by schema generation

### DIFF
--- a/rest_auth/views.py
+++ b/rest_auth/views.py
@@ -105,13 +105,10 @@ class LogoutView(APIView):
     """
     permission_classes = (AllowAny,)
 
-    def get(self, request, *args, **kwargs):
-        if getattr(settings, 'ACCOUNT_LOGOUT_ON_GET', False):
+    if getattr(settings, 'ACCOUNT_LOGOUT_ON_GET', False):
+        def get(self, request, *args, **kwargs):
             response = self.logout(request)
-        else:
-            response = self.http_method_not_allowed(request, *args, **kwargs)
-
-        return self.finalize_response(request, response, *args, **kwargs)
+            return self.finalize_response(request, response, *args, **kwargs)
 
     def post(self, request):
         return self.logout(request)


### PR DESCRIPTION
If `ACCOUNT_LOGOUT_ON_GET` is `False`, a 405 response is appropriately returned.

However, when using DRF's automatic [schema/docs](http://www.django-rest-framework.org/topics/documenting-your-api/) generation, the GET method is still documented.

<img width="614" alt="til api 2017-10-24 19-49-18" src="https://user-images.githubusercontent.com/2379650/31973516-725be56a-b8f4-11e7-8c8f-9e5eb83709a2.png">

Conditionally implementing the `get` method on the LogoutView will prevent the `get` endpoint from appearing in the schema/docs.