### PR TITLE
Handle extra args and kwargs in all POST endpoints

### DIFF
--- a/rest_auth/views.py
+++ b/rest_auth/views.py
@@ -113,7 +113,7 @@ class LogoutView(APIView):
 
         return self.finalize_response(request, response, *args, **kwargs)
 
-    def post(self, request):
+    def post(self, request, *args, **kwargs):
         return self.logout(request)
 
     def logout(self, request):
@@ -193,7 +193,7 @@ class PasswordResetConfirmView(GenericAPIView):
     def dispatch(self, *args, **kwargs):
         return super(PasswordResetConfirmView, self).dispatch(*args, **kwargs)
 
-    def post(self, request):
+    def post(self, request, *args, **kwargs):
         serializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         serializer.save()
@@ -216,7 +216,7 @@ class PasswordChangeView(GenericAPIView):
     def dispatch(self, *args, **kwargs):
         return super(PasswordChangeView, self).dispatch(*args, **kwargs)
 
-    def post(self, request):
+    def post(self, request, *args, **kwargs):
         serializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         serializer.save()


### PR DESCRIPTION
Currently, POST requests fail when DRF's versioning is used:

```
TypeError: post() got an unexpected keyword argument 'version'
```

This is because not all endpoints were handling additional arguments (incl. `version`).
