### PR TITLE
Password whitespace and input in browsable API

### DIFF
--- a/rest_auth/registration/serializers.py
+++ b/rest_auth/registration/serializers.py
@@ -125,8 +125,8 @@ class RegisterSerializer(serializers.Serializer):
         required=allauth_settings.USERNAME_REQUIRED
     )
     email = serializers.EmailField(required=allauth_settings.EMAIL_REQUIRED)
-    password1 = serializers.CharField(write_only=True)
-    password2 = serializers.CharField(write_only=True)
+    password1 = serializers.CharField(write_only=True, style={'input_type': 'password'}, trim_whitespace=False)
+    password2 = serializers.CharField(write_only=True, style={'input_type': 'password'}, trim_whitespace=False)
 
     def validate_username(self, username):
         username = get_adapter().clean_username(username)


### PR DESCRIPTION
- Do not trim password whitespace (`trim_whitespace`, see: http://www.django-rest-framework.org/api-guide/fields/#charfield)
- Mask password input (inspired by https://github.com/encode/django-rest-framework/blob/master/rest_framework/authtoken/serializers.py#L11-L12)