### PR TITLE
Add settings attribute to check if inactive user login is allowed

### DIFF
--- a/rest_auth/serializers.py
+++ b/rest_auth/serializers.py
@@ -91,7 +91,8 @@ class LoginSerializer(serializers.Serializer):
 
         # Did we get back an active user?
         if user:
-            if not user.is_active:
+            # Raises error only if user is deactivated and inactive user login is disabled
+            if not user.is_active and not getattr(settings, 'REST_INACTIVE_USER_LOGIN', False):
                 msg = _('User account is disabled.')
                 raise exceptions.ValidationError(msg)
         else:


### PR DESCRIPTION
This will help if 'AllowAllUsersModelBackend' is used or any other authentication backend that allow inactive user login is used.

If you don't specify 'REST_INACTIVE_USER_LOGIN' it will be False by default which will make django-rest-auth to work normally as before. But, If you set it with True it will not raise an error when you log in using an inactive user.