### PR TITLE
When using a custom user model without a username attribute there was a 500 server error

### DIFF
--- a/rest_auth/serializers.py
+++ b/rest_auth/serializers.py
@@ -58,7 +58,6 @@ class LoginSerializer(serializers.Serializer):
         return user
 
     def validate(self, attrs):
-
         username = attrs.get('username')
         email = attrs.get('email')
         password = attrs.get('password')

--- a/rest_auth/serializers.py
+++ b/rest_auth/serializers.py
@@ -17,7 +17,9 @@ UserModel = get_user_model()
 
 
 class LoginSerializer(serializers.Serializer):
-    username = serializers.CharField(required=False, allow_blank=True)
+    if settings.ACCOUNT_USER_MODEL_USERNAME_FIELD is not None:
+        username = serializers.CharField(required=False, allow_blank=True)
+
     email = serializers.EmailField(required=False, allow_blank=True)
     password = serializers.CharField(style={'input_type': 'password'})
 
@@ -34,7 +36,6 @@ class LoginSerializer(serializers.Serializer):
 
     def _validate_username(self, username, password):
         user = None
-
         if username and password:
             user = authenticate(username=username, password=password)
         else:
@@ -57,6 +58,7 @@ class LoginSerializer(serializers.Serializer):
         return user
 
     def validate(self, attrs):
+
         username = attrs.get('username')
         email = attrs.get('email')
         password = attrs.get('password')
@@ -114,7 +116,6 @@ class TokenSerializer(serializers.ModelSerializer):
     """
     Serializer for Token model.
     """
-
     class Meta:
         model = TokenModel
         fields = ('key',)
@@ -124,10 +125,16 @@ class UserDetailsSerializer(serializers.ModelSerializer):
     """
     User model w/o password
     """
-    class Meta:
-        model = UserModel
-        fields = ('pk', 'username', 'email', 'first_name', 'last_name')
-        read_only_fields = ('email', )
+    if settings.ACCOUNT_USER_MODEL_USERNAME_FIELD is None:
+        class Meta:
+            model = UserModel
+            fields = ('pk', 'email', 'first_name', 'last_name')
+            read_only_fields = ('email', )
+    else:
+        class Meta:
+            model = UserModel
+            fields = ('pk',  'username', 'email', 'first_name', 'last_name')
+            read_only_fields = ('email', )
 
 
 class JWTSerializer(serializers.Serializer):

--- a/rest_auth/serializers.py
+++ b/rest_auth/serializers.py
@@ -36,6 +36,7 @@ class LoginSerializer(serializers.Serializer):
 
     def _validate_username(self, username, password):
         user = None
+
         if username and password:
             user = authenticate(username=username, password=password)
         else:
@@ -115,6 +116,7 @@ class TokenSerializer(serializers.ModelSerializer):
     """
     Serializer for Token model.
     """
+    
     class Meta:
         model = TokenModel
         fields = ('key',)


### PR DESCRIPTION

Request Method: | POST
-- | --
http://xxxxxxxxxx.com:3002/api/v1/login/
2.0.2
ImproperlyConfigured
Field name `username` is not valid for model `User`.
/xxxxx/xxxxxxx/xxxxxx/venv/lib/python3.4/site-packages/rest_framework/serializers.py in build_unknown_field, line 1279
/xxxxx/xxxxxxx/xxxxxx/venv/bin/python
3.4.3
['/xxxxx/xxxxxxx/xxxxxx',  '/usr/lib/python3.4',  '/usr/lib/python3.4/plat-x86_64-linux-gnu',  '/usr/lib/python3.4/lib-dynload',  '/xxxxx/xxxxxxx/xxxxxx/venv/lib/python3.4/site-packages']
Mon, 5 Feb 2018 13:06:11 -0500


By adding the logic in the serializers to reflect theACCOUNT_USER_MODEL_USERNAME_FIELD = None setting I am no longer seeing this error. 

