### PR TITLE
add option to roll back reg on error

### DIFF
--- a/rest_auth/registration/app_settings.py
+++ b/rest_auth/registration/app_settings.py
@@ -17,3 +17,7 @@ def register_permission_classes():
     for klass in getattr(settings, 'REST_AUTH_REGISTER_PERMISSION_CLASSES', tuple()):
         permission_classes.append(import_callable(klass))
     return tuple(permission_classes)
+
+roll_back_register_on_error = getattr(settings,
+                                      'REST_AUTH_ROLL_BACK_REGISTER_ON_ERROR',
+                                      False)


### PR DESCRIPTION
The PR mentioned in #414.

Notes:

- Per the [django standard txn guidelines](https://docs.djangoproject.com/en/2.0/topics/db/transactions/), I add an option to wrap just that particular operation rather than just turning off autocommit (autocommit in that op is IMO much worse than anywhere else).

- I wrap `RegisterView.perform_create` instead of `RegisterView.create` because Open Session In View Considered Harmful.