### PR TITLE
Fix response messages

### DIFF
--- a/rest_auth/registration/serializers.py
+++ b/rest_auth/registration/serializers.py
@@ -1,5 +1,5 @@
 from django.http import HttpRequest
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import ugettext as _
 from django.contrib.auth import get_user_model
 
 try:

--- a/rest_auth/registration/views.py
+++ b/rest_auth/registration/views.py
@@ -1,6 +1,6 @@
 from django.conf import settings
 from django.utils.decorators import method_decorator
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import ugettext as _
 from django.views.decorators.debug import sensitive_post_parameters
 
 from rest_framework.views import APIView

--- a/rest_auth/serializers.py
+++ b/rest_auth/serializers.py
@@ -3,7 +3,7 @@ from django.conf import settings
 from django.contrib.auth.forms import PasswordResetForm, SetPasswordForm
 from django.contrib.auth.tokens import default_token_generator
 from django.utils.http import urlsafe_base64_decode as uid_decoder
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import ugettext as _
 from django.utils.encoding import force_text
 
 from rest_framework import serializers, exceptions

--- a/rest_auth/views.py
+++ b/rest_auth/views.py
@@ -6,7 +6,7 @@ from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.core.exceptions import ObjectDoesNotExist
 from django.utils.decorators import method_decorator
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import ugettext as _
 from django.views.decorators.debug import sensitive_post_parameters
 
 from rest_framework import status


### PR DESCRIPTION
Fixes an issue where the response messages are displayed as a list with one character per item:

`AssertionError: {'detail': ['V', 'e', 'r', 'i', 'f', 'i', 'c', 'a', [80 chars]'.']} != {'detail': 'Verification e-mail sent.'}`

I've tried to write a test to reproduce it but for some reason it works with `ugettext_lazy` and Travis-CI.

However, `ugettext_lazy` shouldn't be used here and I replaced it with `ugettext`. (This made the tests in my project pass.) See the [Django docs](https://docs.djangoproject.com/en/2.0/topics/i18n/translation/#lazy-translation). I checked that the calls to these functions are *not* "located in code paths that are executed at module load time".