### PR TITLE
Pass request to authenticate

### DIFF
--- a/rest_auth/serializers.py
+++ b/rest_auth/serializers.py
@@ -21,11 +21,14 @@ class LoginSerializer(serializers.Serializer):
     email = serializers.EmailField(required=False, allow_blank=True)
     password = serializers.CharField(style={'input_type': 'password'})
 
+    def authenticate(self, **kwargs):
+        return authenticate(self.context['request'], **kwargs)
+
     def _validate_email(self, email, password):
         user = None
 
         if email and password:
-            user = authenticate(email=email, password=password)
+            user = self.authenticate(email=email, password=password)
         else:
             msg = _('Must include "email" and "password".')
             raise exceptions.ValidationError(msg)
@@ -36,7 +39,7 @@ class LoginSerializer(serializers.Serializer):
         user = None
 
         if username and password:
-            user = authenticate(username=username, password=password)
+            user = self.authenticate(username=username, password=password)
         else:
             msg = _('Must include "username" and "password".')
             raise exceptions.ValidationError(msg)
@@ -47,9 +50,9 @@ class LoginSerializer(serializers.Serializer):
         user = None
 
         if email and password:
-            user = authenticate(email=email, password=password)
+            user = self.authenticate(email=email, password=password)
         elif username and password:
-            user = authenticate(username=username, password=password)
+            user = self.authenticate(username=username, password=password)
         else:
             msg = _('Must include either "username" or "email" and "password".')
             raise exceptions.ValidationError(msg)


### PR DESCRIPTION
Normally the `request` is included in the `user_login_failed` signal. This PR adds this feature. Thanks to @nuschk for https://github.com/Tivix/django-rest-auth/issues/340#issuecomment-368827793 that pointed the way ahead.

If you want I could add a test that the said signal contains the `request`.