### PR TITLE
Allow dynamic callback_url and client_class class attributes

### DIFF
--- a/rest_auth/registration/serializers.py
+++ b/rest_auth/registration/serializers.py
@@ -83,8 +83,8 @@ class SocialLoginSerializer(serializers.Serializer):
 
         # Case 2: We received the authorization code
         elif attrs.get('code'):
-            self.callback_url = getattr(view, 'callback_url', None)
-            self.client_class = getattr(view, 'client_class', None)
+            self.callback_url = view.get_callback_url()
+            self.client_class = view.get_client_class()
 
             if not self.callback_url:
                 raise serializers.ValidationError(

--- a/rest_auth/registration/views.py
+++ b/rest_auth/registration/views.py
@@ -123,6 +123,12 @@ class SocialLoginView(LoginView):
     """
     serializer_class = SocialLoginSerializer
 
+    def get_callback_url(self):
+        return getattr(self, 'callback_url', None)
+
+    def get_client_class(self):
+        return getattr(self, 'client_class', None)
+
     def process_login(self):
         get_adapter(self.request).login(self.request, self.user)
 


### PR DESCRIPTION
Callback urls require being absolute, which is pretty cumbersome espacially when dealing with differents environments (dev/staging/production for instance). Being able to provide dynamic callbacks url hence allows for things like this:
```python
class GitHubLogin(SocialLoginView):
    adapter_class = github_views.GitHubOAuth2Adapter
    client_class = OAuth2Client

    # use the same callback url as defined in your GitHub app, this url must be
    # absolute
    def get_callback_url(self):
        return self.request.build_absolute_uri(reverse('github_callback'))

urlpatterns = [
    ...,
    path('auth/github/', GitHubLogin.as_view()),
    path('auth/github/callback/', github_callback, name='github_callback')
]
```
Which really comes in handy in multiple environments.

I also changed `client_class` the same way for code homegeneity concerns (even though I did not have to use it in my own projects).

The "basic way" of declaring these will of course still work:
```python
class GitHubLogin(SocialLoginView):
    adapter_class = github_views.GitHubOAuth2Adapter
    client_class = OAuth2Client
    callback_url = 'http://localhost:8000/auth/github/callback/'
```