### PR TITLE
Minor package maintenance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,26 +1,35 @@
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]
+*$py.class
 
 # C extensions
 *.so
 
 # Distribution / packaging
 .Python
-env/
-bin/
 build/
 develop-eggs/
 dist/
+downloads/
 eggs/
+.eggs/
 lib/
 lib64/
 parts/
 sdist/
 var/
+wheels/
 *.egg-info/
 .installed.cfg
 *.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
 
 # Installer logs
 pip-log.txt
@@ -30,28 +39,66 @@ pip-delete-this-directory.txt
 htmlcov/
 .tox/
 .coverage
+.coverage.*
 .cache
 nosetests.xml
 coverage.xml
-coverage_html
+*.cover
+.hypothesis/
+.pytest_cache/
 
-# Mr Developer
-.mr.developer.cfg
-.project
-.pydevproject
-
-# Rope
-.ropeproject
+# Translations
+*.mo
+*.pot
 
 # Django stuff:
 *.log
-*.pot
+local_settings.py
+db.sqlite3
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
 
 # Sphinx documentation
 docs/_build/
 
-.DS_Store
-db.sqlite3
+# PyBuilder
+target/
 
-# IntelliJ IDE files
-.idea
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/

--- a/flake8
+++ b/flake8
@@ -1,4 +1,0 @@
-[flake8]
-max-line-length = 120
-exclude = docs/*,demo/*
-ignore = F403

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,8 +1,13 @@
-# .coveragerc to control coverage.py
-[run]
+[flake8]
+max-line-length = 120
+exclude = docs/*,demo/*
+ignore = F403
+
+
+[coverage:run]
 omit=*site-packages*,*distutils*,*migrations*
 
-[report]
+[coverage:report]
 # Regexes for lines to exclude from consideration
 exclude_lines =
     # Have to re-enable the standard pragma
@@ -22,5 +27,5 @@ exclude_lines =
 
 ignore_errors = True
 
-[html]
+[coverage:html]
 directory = coverage_html

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,11 @@
+[bdist_wheel]
+universal = 1
+
+
+[metadata]
+license_file = LICENSE
+
+
 [flake8]
 max-line-length = 120
 exclude = docs/*,demo/*

--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,8 @@
 #!/usr/bin/env python
 
-try:
-    from setuptools import setup, find_packages
-except ImportError:
-    from ez_setup import use_setuptools
-    use_setuptools()
-    from setuptools import setup, find_packages
-
-
 import os
+from setuptools import setup, find_packages
+
 
 here = os.path.dirname(os.path.abspath(__file__))
 f = open(os.path.join(here, 'README.rst'))


### PR DESCRIPTION
- EZ setup has been deprecated for a long time, removed from setup.py
- Merge `flake8` and `.coveragerc` into `setup.cfg`. Most tools also use `setup.cfg`, in addition to their project-specific configs. A few other small changes
- Update .gitignore