### PR TITLE
Disable whitespace trimming in password related serializers

### DIFF
--- a/rest_auth/registration/serializers.py
+++ b/rest_auth/registration/serializers.py
@@ -170,8 +170,8 @@ class RegisterSerializer(serializers.Serializer):
         required=allauth_settings.USERNAME_REQUIRED
     )
     email = serializers.EmailField(required=allauth_settings.EMAIL_REQUIRED)
-    password1 = serializers.CharField(write_only=True)
-    password2 = serializers.CharField(write_only=True)
+    password1 = serializers.CharField(write_only=True,trim_whitespace=False)
+    password2 = serializers.CharField(write_only=True,trim_whitespace=False)
 
     def validate_username(self, username):
         username = get_adapter().clean_username(username)

--- a/rest_auth/serializers.py
+++ b/rest_auth/serializers.py
@@ -19,7 +19,7 @@ UserModel = get_user_model()
 class LoginSerializer(serializers.Serializer):
     username = serializers.CharField(required=False, allow_blank=True)
     email = serializers.EmailField(required=False, allow_blank=True)
-    password = serializers.CharField(style={'input_type': 'password'})
+    password = serializers.CharField(style={'input_type': 'password'},trim_whitespace=False)
 
     def _validate_email(self, email, password):
         user = None
@@ -187,8 +187,8 @@ class PasswordResetConfirmSerializer(serializers.Serializer):
     """
     Serializer for requesting a password reset e-mail.
     """
-    new_password1 = serializers.CharField(max_length=128)
-    new_password2 = serializers.CharField(max_length=128)
+    new_password1 = serializers.CharField(max_length=128,trim_whitespace=False)
+    new_password2 = serializers.CharField(max_length=128,trim_whitespace=False)
     uid = serializers.CharField()
     token = serializers.CharField()
 
@@ -224,9 +224,9 @@ class PasswordResetConfirmSerializer(serializers.Serializer):
 
 
 class PasswordChangeSerializer(serializers.Serializer):
-    old_password = serializers.CharField(max_length=128)
-    new_password1 = serializers.CharField(max_length=128)
-    new_password2 = serializers.CharField(max_length=128)
+    old_password = serializers.CharField(max_length=128,trim_whitespace=False)
+    new_password1 = serializers.CharField(max_length=128,trim_whitespace=False)
+    new_password2 = serializers.CharField(max_length=128,trim_whitespace=False)
 
     set_password_form_class = SetPasswordForm
 


### PR DESCRIPTION
Disabled password whitespace trimming as that interferes when password ends with a space, which although should be allowed results in a mutated password. Same way, if a user enters 8 black spaces, the password is rejected stating that it is blank.

For more information check: https://github.com/Cloud-CV/EvalAI/issues/1543