### PR TITLE
Add missing django-allauth empty View

### DIFF
--- a/rest_auth/registration/urls.py
+++ b/rest_auth/registration/urls.py
@@ -7,7 +7,7 @@ urlpatterns = [
     url(r'^$', RegisterView.as_view(), name='rest_register'),
     url(r'^verify-email/$', VerifyEmailView.as_view(), name='rest_verify_email'),
 
-    # This url is used by django-allauth and empty TemplateView is
+    # These two urls are used by django-allauth and empty TemplateView were
     # defined just to allow reverse() call inside app, for example when email
     # with verification link is being sent, then it's required to render email
     # content.
@@ -18,6 +18,8 @@ urlpatterns = [
     # If you don't want to use API on that step, then just use ConfirmEmailView
     # view from:
     # django-allauth https://github.com/pennersr/django-allauth/blob/master/allauth/account/views.py
+    url(r'^account-email-verification-sent/$', TemplateView.as_view(),
+        name='account_email_verification_sent'),
     url(r'^account-confirm-email/(?P<key>[-:\w]+)/$', TemplateView.as_view(),
         name='account_confirm_email'),
 ]


### PR DESCRIPTION
Hello,

A `NoReverseMatch` exception is thrown during signup when using _django-allauth_ and `ACCOUNT_EMAIL_VERIFICATION` is set to `'mandatory'`.
This happen because _django-allouth_ tries to reverse a missing route: https://github.com/pennersr/django-allauth/blob/master/allauth/account/adapter.py#L458.

I added an empty view to avoid this.
The view was already there some time ago and removed on this commit: https://github.com/Tivix/django-rest-auth/commit/0fc4d56dae860be87809d8c9368f7cae28e14a44#diff-c6d8840dbabc2fb43a1d18876004f17a. Please let me know if it was any reason for this, I can't see any.

This can also be avoided by importing _django-allauth_ urls but I would prefer not to. Also, the documentation doesn't say you should.