### PR TITLE
removed unusable endpoint when ACCOUNT_LOGOUT_ON_GET==False

### DIFF
--- a/rest_auth/views.py
+++ b/rest_auth/views.py
@@ -105,12 +105,13 @@ class LogoutView(APIView):
     """
     permission_classes = (AllowAny,)
 
-    def get(self, request, *args, **kwargs):
-        if getattr(settings, 'ACCOUNT_LOGOUT_ON_GET', False):
-            response = self.logout(request)
-        else:
-            response = self.http_method_not_allowed(request, *args, **kwargs)
+    def __init__(self):
+        if getattr(settings, 'ACCOUNT_LOGOUT_ON_GET', True):
+            self.get = self._get
+        super().__init__()
 
+    def _get(self, request, *args, **kwargs):
+        response = self.logout(request)
         return self.finalize_response(request, response, *args, **kwargs)
 
     def post(self, request, *args, **kwargs):


### PR DESCRIPTION
This commit removes the GET method from the LogoutView when  ACCOUNT_LOGOUT_ON_GET==False.
Before this commit, the logout endpoint accepts GET requests and appears in the [auto-generated DRF docs](https://bit.ly/2OMpwKx), but it's not usable.