### PR TITLE
expand JWT acronym in docs

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -205,8 +205,8 @@ You can also use the following views to check all social accounts attached to th
     ]
 
 
-JWT Support (optional)
-----------------------
+JSON Web Token (JWT) Support (optional)
+---------------------------------------
 
 By default ``django-rest-auth`` uses Django's Token-based authentication. If you want to use JWT authentication, follow these steps:
 


### PR DESCRIPTION
First use of acronyms should always be expanded for newcomers.