### PR TITLE
Adds django-allauth to dev-requirements.txt

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,3 +1,4 @@
 --editable .
 responses>=0.5.0
 djangorestframework-jwt
+django-allauth


### PR DESCRIPTION
The `django-allauth` dependency was missing, which caused an error bootstrapping the dev environment with `virtualenv`.