### PR TITLE
Login signal

### DIFF
--- a/rest_auth/tests/mixins.py
+++ b/rest_auth/tests/mixins.py
@@ -93,6 +93,7 @@ class TestsMixin(object):
         self.fb_connect_url = reverse('fb_connect')
         self.tw_connect_url = reverse('tw_connect')
         self.social_account_list_url = reverse('social_account_list')
+        self.signal_sent = False
 
     def _login(self):
         payload = {

--- a/rest_auth/tests/test_api.py
+++ b/rest_auth/tests/test_api.py
@@ -159,7 +159,9 @@ class APIBasicTests(TestsMixin, TestCase):
         }
         get_user_model().objects.create_user(self.USERNAME, '', self.PASS)
 
+        user_logged_in.connect(self.on_login)
         self.post(self.login_url, data=payload, status_code=200)
+        self.assertTrue(self.signal_sent)
         self.assertEqual('token' in self.response.json.keys(), True)
         self.token = self.response.json['token']
 
@@ -180,7 +182,10 @@ class APIBasicTests(TestsMixin, TestCase):
         user = get_user_model().objects.create_user(self.USERNAME, self.EMAIL, self.PASS)
 
         # test auth by email
+
+        user_logged_in.connect(self.on_login)
         self.post(self.login_url, data=payload, status_code=200)
+        self.assertTrue(self.signal_sent)
         self.assertEqual('key' in self.response.json.keys(), True)
         self.token = self.response.json['key']
 

--- a/rest_auth/views.py
+++ b/rest_auth/views.py
@@ -1,7 +1,7 @@
 from django.contrib.auth import (
     login as django_login,
-    logout as django_logout
-)
+    logout as django_logout,
+    user_logged_in)
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.core.exceptions import ObjectDoesNotExist
@@ -69,6 +69,12 @@ class LoginView(GenericAPIView):
 
         if getattr(settings, 'REST_SESSION_LOGIN', True):
             self.process_login()
+        else:
+            '''
+            Send user logged in because it's only send on django_login but if REST_SESSION_LOGIN is disable it
+            is not going to be sent
+            '''
+            user_logged_in.send(sender=self.user.__class__, request=self.request, user=self.user)
 
     def get_response(self):
         serializer_class = self.get_response_serializer()


### PR DESCRIPTION
Send `user_logged_in` signal on `REST_SESSION_LOGiIN` when is set to false. This is because when this variable is disable, `django_login` is not executed and then `user_logged_in`signal is not going to be sent.