### PR TITLE
Pass serializer context in RegisterView.get_response_data #478

### DIFF
--- a/rest_auth/registration/views.py
+++ b/rest_auth/registration/views.py
@@ -50,14 +50,16 @@ class RegisterView(CreateAPIView):
                 allauth_settings.EmailVerificationMethod.MANDATORY:
             return {"detail": _("Verification e-mail sent.")}
 
+        context = self.get_serializer_context()
+
         if getattr(settings, 'REST_USE_JWT', False):
             data = {
                 'user': user,
                 'token': self.token
             }
-            return JWTSerializer(data).data
+            return JWTSerializer(data, context=context).data
         else:
-            return TokenSerializer(user.auth_token).data
+            return TokenSerializer(user.auth_token, context=context).data
 
     def create(self, request, *args, **kwargs):
         serializer = self.get_serializer(data=request.data)


### PR DESCRIPTION
Pass serializer context to `TokenSerializer` / `JWTSerializer` so extensions of these serializers can make use of it to implement custom logic.

Closes #478 