### PR TITLE
social login should also optionally get the refresh token and pass th…

### DIFF
--- a/rest_auth/registration/serializers.py
+++ b/rest_auth/registration/serializers.py
@@ -35,6 +35,7 @@ class SocialAccountSerializer(serializers.ModelSerializer):
 
 class SocialLoginSerializer(serializers.Serializer):
     access_token = serializers.CharField(required=False, allow_blank=True)
+    refresh_token = serializers.CharField(required=False, allow_blank=True)
     code = serializers.CharField(required=False, allow_blank=True)
 
     def _get_request(self):
@@ -110,12 +111,17 @@ class SocialLoginSerializer(serializers.Serializer):
             )
             token = client.get_access_token(code)
             access_token = token['access_token']
+            refresh_token = token.get('refresh_token')
 
         else:
             raise serializers.ValidationError(
                 _("Incorrect input. access_token or code is required."))
 
-        social_token = adapter.parse_token({'access_token': access_token})
+        token_dict = {'access_token': access_token}
+        if refresh_token:
+            # Also pass the refresh_token if there is one
+            token_dict.update({'refresh_token': refresh_token})
+        social_token = adapter.parse_token(token_dict)
         social_token.app = app
 
         try:


### PR DESCRIPTION
…is token the `adapter.parse_token`, so that `SocialToken` instance also caches the `refresh_token` and refresh is possible for "offline" mode (e.g. tested with google api offline mode)