### PR TITLE
Resend account verification email

### DIFF
--- a/rest_auth/registration/serializers.py
+++ b/rest_auth/registration/serializers.py
@@ -216,5 +216,5 @@ class RegisterSerializer(serializers.Serializer):
 class VerifyEmailSerializer(serializers.Serializer):
     key = serializers.CharField()
 
-class ResendEmailVerificationSerializer(serializers.Serializer):
+class ResendVerificationEmailSerializer(serializers.Serializer):
     email = serializers.EmailField()

--- a/rest_auth/registration/serializers.py
+++ b/rest_auth/registration/serializers.py
@@ -215,3 +215,6 @@ class RegisterSerializer(serializers.Serializer):
 
 class VerifyEmailSerializer(serializers.Serializer):
     key = serializers.CharField()
+
+class ResendEmailVerificationSerializer(serializers.Serializer):
+    email = serializers.EmailField()

--- a/rest_auth/registration/urls.py
+++ b/rest_auth/registration/urls.py
@@ -1,10 +1,15 @@
 from django.views.generic import TemplateView
 from django.conf.urls import url
 
-from .views import RegisterView, VerifyEmailView
+from .views import (
+    RegisterView,
+    VerifyEmailView,
+    ResendEmailVerification
+)
 
 urlpatterns = [
     url(r'^$', RegisterView.as_view(), name='rest_register'),
+    url(r'^resend-verification-email/$', ResendEmailVerification.as_view(), name='rest_resend_verification_email'),
     url(r'^verify-email/$', VerifyEmailView.as_view(), name='rest_verify_email'),
 
     # This url is used by django-allauth and empty TemplateView is

--- a/rest_auth/registration/urls.py
+++ b/rest_auth/registration/urls.py
@@ -4,14 +4,13 @@ from django.conf.urls import url
 from .views import (
     RegisterView,
     VerifyEmailView,
-    ResendEmailVerification
+    ResendVerificationEmail
 )
 
 urlpatterns = [
     url(r'^$', RegisterView.as_view(), name='rest_register'),
-    url(r'^resend-verification-email/$', ResendEmailVerification.as_view(), name='rest_resend_verification_email'),
+    url(r'^resend-verification-email/$', ResendVerificationEmail.as_view(), name='rest_resend_verification_email'),
     url(r'^verify-email/$', VerifyEmailView.as_view(), name='rest_verify_email'),
-
     # This url is used by django-allauth and empty TemplateView is
     # defined just to allow reverse() call inside app, for example when email
     # with verification link is being sent, then it's required to render email

--- a/rest_auth/registration/views.py
+++ b/rest_auth/registration/views.py
@@ -25,7 +25,7 @@ from rest_auth.app_settings import (TokenSerializer,
                                     create_token)
 from rest_auth.models import TokenModel
 from rest_auth.registration.serializers import (VerifyEmailSerializer,
-                                                ResendEmailVerificationSerializer,
+                                                ResendVerificationEmailSerializer,
                                                 SocialLoginSerializer,
                                                 SocialAccountSerializer,
                                                 SocialConnectSerializer)
@@ -100,8 +100,8 @@ class VerifyEmailView(APIView, ConfirmEmailView):
         return Response({'detail': _('ok')}, status=status.HTTP_200_OK)
 
 
-class ResendEmailVerification(GenericAPIView):
-    serializer_class = ResendEmailVerificationSerializer
+class ResendVerificationEmail(GenericAPIView):
+    serializer_class = ResendVerificationEmailSerializer
     permission_classes = (AllowAny,)
     allowed_methods = ('POST', 'OPTIONS', 'HEAD')
     

--- a/rest_auth/tests/test_api.py
+++ b/rest_auth/tests/test_api.py
@@ -11,6 +11,8 @@ from rest_framework.test import APIRequestFactory
 from rest_auth.registration.views import RegisterView
 from rest_auth.registration.app_settings import register_permission_classes
 
+from allauth.account.models import EmailAddress
+
 from .mixins import TestsMixin, CustomPermissionClass
 
 try:
@@ -516,3 +518,66 @@ class APIBasicTests(TestsMixin, TestCase):
 
         self.post(self.login_url, data=payload, status_code=status.HTTP_200_OK)
         self.get(self.logout_url, status_code=status.HTTP_405_METHOD_NOT_ALLOWED)
+
+    @override_settings(ACCOUNT_EMAIL_VERIFICATION='mandatory')
+    def test_resend_account_verification_email(self):      
+        result = self.post(
+            self.register_url,
+            data=self.REGISTRATION_DATA_WITH_EMAIL,
+            status_code=status.HTTP_201_CREATED
+        )
+
+        self.assertEqual(EmailAddress.objects.count(), 1)
+        self.assertEqual(EmailAddress.objects.first().email, self.EMAIL)
+        self.assertEqual(EmailAddress.objects.first().verified, False)
+
+        self.post(
+            reverse('rest_resend_verification_email'),
+            data={
+                'email': self.EMAIL
+            },
+            status_code=status.HTTP_200_OK
+        )
+
+        self.assertEqual(len(mail.outbox), 2)
+
+    @override_settings(ACCOUNT_EMAIL_VERIFICATION='mandatory')
+    def test_resend_not_registered_account_verification_email(self):
+        self.assertEqual(EmailAddress.objects.count(), 0)
+        
+        self.post(
+            reverse('rest_resend_verification_email'),
+            data={
+                'email': self.EMAIL
+            },
+            status_code=status.HTTP_200_OK
+        )
+
+        self.assertEqual(len(mail.outbox), 0)
+
+    @override_settings(ACCOUNT_EMAIL_VERIFICATION='mandatory')
+    def test_resend_already_verified_account_verification_email(self):
+        result = self.post(
+            self.register_url,
+            data=self.REGISTRATION_DATA_WITH_EMAIL,
+            status_code=status.HTTP_201_CREATED
+        )
+
+        self.assertEqual(EmailAddress.objects.count(), 1)
+        self.assertEqual(EmailAddress.objects.first().email, self.EMAIL)
+        self.assertEqual(EmailAddress.objects.first().verified, False)
+        self.assertEqual(len(mail.outbox), 1)
+
+        email_address = EmailAddress.objects.first()
+        email_address.verified = True
+        email_address.save()
+
+        self.post(
+            reverse('rest_resend_verification_email'),
+            data={
+                'email': self.EMAIL
+            },
+            status_code=status.HTTP_200_OK
+        )
+
+        self.assertEqual(len(mail.outbox), 1)


### PR DESCRIPTION
### Feature for an endpoint for resending a verification email to a registered user.
A verification email will be sent only if the email provided by the user is valid, registered in the application and is not verified yet.
Any other invalid email or a not registered email in the application and any other email already verified will be ignored, and no verification email will be sent.