### PR TITLE
Un-comment required app in settings

### DIFF
--- a/demo/demo/settings.py
+++ b/demo/demo/settings.py
@@ -31,7 +31,7 @@ INSTALLED_APPS = (
     'django.contrib.auth',
     'django.contrib.contenttypes',
     'django.contrib.sessions',
-    # 'django.contrib.messages',
+    'django.contrib.messages',
     'django.contrib.staticfiles',
     'django.contrib.sites',
 


### PR DESCRIPTION
`django.contrib.messages` is required, so I have uncommented it in settings.py