### PR TITLE
Django axes integration in demo project

### DIFF
--- a/demo/Dockerfile
+++ b/demo/Dockerfile
@@ -1,0 +1,8 @@
+FROM python:3
+ENV PYTHONUNBUFFERED 1
+RUN mkdir /code
+WORKDIR /code
+COPY requirements.txt /code/
+RUN pip install -r requirements.txt
+COPY . /code/
+

--- a/demo/demo/settings.py
+++ b/demo/demo/settings.py
@@ -31,7 +31,7 @@ INSTALLED_APPS = (
     'django.contrib.auth',
     'django.contrib.contenttypes',
     'django.contrib.sessions',
-    # 'django.contrib.messages',
+    'django.contrib.messages',
     'django.contrib.staticfiles',
     'django.contrib.sites',
 
@@ -39,12 +39,15 @@ INSTALLED_APPS = (
     'rest_framework.authtoken',
     'rest_auth',
 
+
     'allauth',
     'allauth.account',
     'rest_auth.registration',
     'allauth.socialaccount',
     'allauth.socialaccount.providers.facebook',
     'rest_framework_swagger',
+
+    'axes',
 )
 
 MIDDLEWARE = (
@@ -54,10 +57,9 @@ MIDDLEWARE = (
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
-)
 
-# For backwards compatibility for Django 1.8
-MIDDLEWARE_CLASSES = MIDDLEWARE
+    'axes.middleware.AxesMiddleware',
+)
 
 ROOT_URLCONF = 'demo.urls'
 
@@ -126,4 +128,28 @@ REST_FRAMEWORK = {
 SWAGGER_SETTINGS = {
     'LOGIN_URL': 'login',
     'LOGOUT_URL': 'logout',
+}
+
+AUTHENTICATION_BACKENDS = [
+
+    # AxesBackend should be the first backend in the AUTHENTICATION_BACKENDS list.
+    'axes.backends.AxesBackend',
+
+    # Required for rest-auth when using Axes to prevent 'Unable to log in with provided credentials.'
+    'allauth.account.auth_backends.AuthenticationBackend',
+
+    # Django ModelBackend is the default authentication backend.
+    'django.contrib.auth.backends.ModelBackend',
+]
+
+CACHES = {
+    'default': {
+        'BACKEND': 'django.core.cache.backends.db.DatabaseCache',
+        'LOCATION': 'django_database_cache',
+    }
+}
+
+REST_AUTH_SERIALIZERS = {
+    'LOGIN_SERIALIZER': 'myapp.serializers.RestAuthLoginSerializer',
+    # 'TOKEN_SERIALIZER': 'path.to.custom.TokenSerializer',
 }

--- a/demo/demo/settings.py
+++ b/demo/demo/settings.py
@@ -150,6 +150,6 @@ CACHES = {
 }
 
 REST_AUTH_SERIALIZERS = {
-    'LOGIN_SERIALIZER': 'myapp.serializers.RestAuthLoginSerializer',
+    'LOGIN_SERIALIZER': 'myapp.serializers.RestAuthAxesLoginSerializer',
     # 'TOKEN_SERIALIZER': 'path.to.custom.TokenSerializer',
 }

--- a/demo/docker-compose.yml
+++ b/demo/docker-compose.yml
@@ -1,0 +1,13 @@
+version: '3'
+
+services:
+  web:
+    build: .
+    image: gableroux/django-rest-auth-demo
+    command: python manage.py runserver 0.0.0.0:1234
+    environment:
+      PYTHONUNBUFFERED: 1
+    volumes:
+      - .:/code
+    ports:
+      - "1234:1234"

--- a/demo/myapp/admin.py
+++ b/demo/myapp/admin.py
@@ -1,0 +1,3 @@
+from django.contrib import admin
+
+# Register your models here.

--- a/demo/myapp/apps.py
+++ b/demo/myapp/apps.py
@@ -1,0 +1,5 @@
+from django.apps import AppConfig
+
+
+class MyappConfig(AppConfig):
+    name = 'myapp'

--- a/demo/myapp/models.py
+++ b/demo/myapp/models.py
@@ -1,0 +1,3 @@
+from django.db import models
+
+# Create your models here.

--- a/demo/myapp/serializers.py
+++ b/demo/myapp/serializers.py
@@ -1,0 +1,16 @@
+from axes.helpers import get_lockout_message
+from rest_auth import serializers
+from rest_auth.serializers import LoginSerializer
+from rest_framework import exceptions
+
+
+# noinspection PyAbstractClass
+class RestAuthLoginSerializer(LoginSerializer):
+
+    def validate(self, attrs):
+        try:
+            attrs = super().validate(attrs)
+        except exceptions.ValidationError:
+            if getattr(self.context['request'], 'axes_locked_out', None):
+                raise serializers.ValidationError(get_lockout_message())
+        return attrs

--- a/demo/myapp/serializers.py
+++ b/demo/myapp/serializers.py
@@ -5,12 +5,12 @@ from rest_framework import exceptions
 
 
 # noinspection PyAbstractClass
-class RestAuthLoginSerializer(LoginSerializer):
+class RestAuthAxesLoginSerializer(LoginSerializer):
 
     def validate(self, attrs):
         try:
-            attrs = super().validate(attrs)
-        except exceptions.ValidationError:
+            return super().validate(attrs)
+        except exceptions.ValidationError as e:
             if getattr(self.context['request'], 'axes_locked_out', None):
                 raise serializers.ValidationError(get_lockout_message())
-        return attrs
+            raise e

--- a/demo/myapp/serializers.py
+++ b/demo/myapp/serializers.py
@@ -7,7 +7,7 @@ from rest_framework import exceptions
 # noinspection PyAbstractClass
 class RestAuthAxesLoginSerializer(LoginSerializer):
 
-    def validate(self, attrs):
+    def validate(self, attrs) -> dict:
         try:
             return super().validate(attrs)
         except exceptions.ValidationError as e:

--- a/demo/myapp/tests.py
+++ b/demo/myapp/tests.py
@@ -1,0 +1,3 @@
+from django.test import TestCase
+
+# Create your tests here.

--- a/demo/myapp/tests.py
+++ b/demo/myapp/tests.py
@@ -1,3 +1,0 @@
-from django.test import TestCase
-
-# Create your tests here.

--- a/demo/myapp/tests/test_serializers.py
+++ b/demo/myapp/tests/test_serializers.py
@@ -1,0 +1,71 @@
+from django.conf import settings
+from django.contrib.auth.models import User
+from django.http import HttpRequest
+from django.test import TestCase
+from rest_framework.exceptions import ValidationError
+
+from myapp import serializers
+
+
+class TestRestAuthAxesLoginSerializer(TestCase):
+
+    def setUp(self) -> None:
+        self.request = HttpRequest()
+
+    def test_validate_wrong_user(self) -> None:
+        serializer = serializers.RestAuthAxesLoginSerializer(
+            context=dict(request=self.request)
+        )
+        with self.assertRaisesMessage(ValidationError, 'Unable to log in with provided credentials.'):
+            serializer.validate({
+                'username': 'test',
+                'email': 'test@example.com',
+                'password': 'test'
+            })
+
+    def test_validate_good_user(self) -> None:
+        User.objects.create_user(
+            username='test',
+            email='test@example.com',
+            password='test'
+        )
+        serializer = serializers.RestAuthAxesLoginSerializer(
+            context=dict(request=self.request)
+        )
+        attrs = serializer.validate({
+            'username': 'test',
+            'email': 'test@example.com',
+            'password': 'test'
+        })
+
+        self.assertIsNotNone(attrs)
+
+    def test_validate_axes_locked_out(self) -> None:
+        good_password_creds = {
+            'username': 'test',
+            'email': 'test@example.com',
+            'password': 'good_password'
+        }
+
+        bad_password_creds = {
+            'username': 'test',
+            'email': 'test@example.com',
+            'password': 'bad_password'
+        }
+
+        User.objects.create_user(**good_password_creds)
+        serializer = serializers.RestAuthAxesLoginSerializer(
+            context=dict(request=self.request)
+        )
+
+        for i in range(settings.AXES_FAILURE_LIMIT - 1):
+            with self.assertRaisesMessage(ValidationError, 'Unable to log in with provided credentials.'):
+                serializer.validate(bad_password_creds)
+
+        account_locked_message = 'Account locked: too many login attempts. Contact an admin to unlock your account.'
+
+        with self.assertRaisesMessage(ValidationError, account_locked_message):
+            serializer.validate(bad_password_creds)
+
+        with self.assertRaisesMessage(ValidationError, account_locked_message):
+            serializer.validate(good_password_creds)

--- a/demo/myapp/views.py
+++ b/demo/myapp/views.py
@@ -1,0 +1,3 @@
+from django.shortcuts import render
+
+# Create your views here.

--- a/demo/requirements.pip
+++ b/demo/requirements.pip
@@ -1,6 +1,0 @@
-django>=1.9.0
-django-rest-auth==0.9.5
-djangorestframework>=3.7.0
-django-allauth>=0.24.1
-six==1.9.0
-django-rest-swagger==2.0.7

--- a/demo/requirements.txt
+++ b/demo/requirements.txt
@@ -4,3 +4,4 @@ djangorestframework>=3.9.4
 django-allauth>=0.39.1
 six==1.12.0
 django-rest-swagger==2.2.0
+django-axes==5.0.7

--- a/demo/requirements.txt
+++ b/demo/requirements.txt
@@ -1,0 +1,6 @@
+django==1.11.22
+django-rest-auth==0.9.5
+djangorestframework>=3.9.4
+django-allauth>=0.39.1
+six==1.12.0
+django-rest-swagger==2.2.0

--- a/docs/demo.rst
+++ b/docs/demo.rst
@@ -10,7 +10,7 @@ Do these steps to make it running (ideally in virtualenv).
     cd /tmp
     git clone https://github.com/Tivix/django-rest-auth.git
     cd django-rest-auth/demo/
-    pip install -r requirements.pip
+    pip install -r requirements.txt
     python manage.py migrate --settings=demo.settings --noinput
     python manage.py runserver --settings=demo.settings
 


### PR DESCRIPTION
Hi, I'm not sure this should actually get merged as I think there should be a better solution to support this, but I managed to get django-axes working with django-rest-auth in the demo project this way (so this way is compatible with latest version of django-rest-auth.

A better solution would be to check for django-axes and see if it's installed, then implement the logic I added in `serializers.py` into the `django-rest-auth` library instead of the demo.

I also added a few tests while doing it. So most changes are in `demo` folder. The only exception is an update in `docs` folder if this ever get merged. It's safe to merge this, the fix in the library would need to clean the demo project.

- [x] Updated all requirements
- [x] Rename `requirements.pip` to `requirements.txt` (and updated docs for this)
- [x] Add a `RestAuthAxesLoginSerializer` that will write the right message if `axes_locked_out` is set and True
- [x] Add docker support for demo project (with updated documentation)
- [x] Configure django-axes in settings