### PR TITLE
Store refresh tokens and add tests for authorization code flows

### DIFF
--- a/rest_auth/registration/serializers.py
+++ b/rest_auth/registration/serializers.py
@@ -115,7 +115,11 @@ class SocialLoginSerializer(serializers.Serializer):
             raise serializers.ValidationError(
                 _("Incorrect input. access_token or code is required."))
 
-        social_token = adapter.parse_token({'access_token': access_token})
+        # To allow allauth to store the refresh token as well as the access token, we
+        # make another minor adjustment, not yet in all-auth.
+        # https://github.com/Tivix/django-rest-auth/pull/486
+        # social_token = adapter.parse_token({'access_token': access_token})
+        social_token = adapter.parse_token(token)
         social_token.app = app
 
         try:

--- a/rest_auth/registration/serializers.py
+++ b/rest_auth/registration/serializers.py
@@ -73,6 +73,7 @@ class SocialLoginSerializer(serializers.Serializer):
 
         adapter = adapter_class(request)
         app = adapter.get_provider().get_app(request)
+        token_attrs = {}
 
         # More info on code vs access_token
         # http://stackoverflow.com/questions/8666316/facebook-oauth-2-0-code-and-token
@@ -80,6 +81,7 @@ class SocialLoginSerializer(serializers.Serializer):
         # Case 1: We received the access_token
         if attrs.get('access_token'):
             access_token = attrs.get('access_token')
+            token_attrs['access_token'] = access_token
 
         # Case 2: We received the authorization code
         elif attrs.get('code'):
@@ -108,8 +110,8 @@ class SocialLoginSerializer(serializers.Serializer):
                 self.callback_url,
                 scope
             )
-            token = client.get_access_token(code)
-            access_token = token['access_token']
+            token_attrs = client.get_access_token(code)
+            access_token = token_attrs['access_token']
 
         else:
             raise serializers.ValidationError(
@@ -119,7 +121,7 @@ class SocialLoginSerializer(serializers.Serializer):
         # make another minor adjustment, not yet in all-auth.
         # https://github.com/Tivix/django-rest-auth/pull/486
         # social_token = adapter.parse_token({'access_token': access_token})
-        social_token = adapter.parse_token(token)
+        social_token = adapter.parse_token(token_attrs)
         social_token.app = app
 
         try:

--- a/rest_auth/tests/urls.py
+++ b/rest_auth/tests/urls.py
@@ -3,6 +3,7 @@ from django.views.generic import TemplateView
 from . import django_urls
 
 from allauth.socialaccount.providers.facebook.views import FacebookOAuth2Adapter
+from allauth.socialaccount.providers.oauth2.client import OAuth2Client
 from allauth.socialaccount.providers.twitter.views import TwitterOAuthAdapter
 
 from rest_framework.decorators import api_view
@@ -19,6 +20,8 @@ from rest_auth.social_serializers import (
 
 class FacebookLogin(SocialLoginView):
     adapter_class = FacebookOAuth2Adapter
+    callback_url = 'https://localhost:8000'
+    client_class = OAuth2Client
 
 
 class TwitterLogin(SocialLoginView):
@@ -28,6 +31,8 @@ class TwitterLogin(SocialLoginView):
 
 class FacebookConnect(SocialConnectView):
     adapter_class = FacebookOAuth2Adapter
+    callback_url = 'https://localhost:8000'
+    client_class = OAuth2Client
 
 
 class TwitterConnect(SocialConnectView):


### PR DESCRIPTION
This is a quick pass at storing refresh tokens when the authorization code flow is used for login or connect.

I've also added some tests so that the authorization code flows are now somewhat covered.

This was inspired by https://github.com/Tivix/django-rest-auth/pull/486 - I needed it now, though.

Curious to hear your thoughts. Thanks!