### PR TITLE
Return login data from SocialLoginSerializer.validate for views to use

### DIFF
--- a/rest_auth/registration/serializers.py
+++ b/rest_auth/registration/serializers.py
@@ -142,6 +142,10 @@ class SocialLoginSerializer(serializers.Serializer):
             login.lookup()
             login.save(request, connect=True)
 
+        # we return the login data (and so User and SocialAccount instances) here
+        # such that custom login and connect views can render suitable responses
+        attrs['login'] = login
+        # we still return `user` here for backwards compatibility
         attrs['user'] = login.account.user
 
         return attrs


### PR DESCRIPTION
I needed to customize `SocialConnectView`, such that in its response it renders the `SocialAccount` newly created or updated. Since this library persists the new `SocialAccount` instance in the call to `SocialLoginSerializer.validate`, this meant returning the social login in the validated attributes, such that a custom connect view could then render the new account using `SocialAccountSerializer`.

This is a small change allowing that kind of flexibility.