### PR TITLE
Update ReadMe with state of repo

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,8 @@
 Welcome to django-rest-auth
 ===========================
 
+Repository is unmaintained at the moment (on pause). More info can be found on this issue page: https://github.com/Tivix/django-rest-auth/issues/568
+
 .. image:: https://travis-ci.org/Tivix/django-rest-auth.svg
     :target: https://travis-ci.org/Tivix/django-rest-auth
 


### PR DESCRIPTION
According to issue: https://github.com/Tivix/django-rest-auth/issues/568. This repository is currently unmaintained; this information should be obvious to new users planning to use the package. Hence made this PR.

Thanks.