### PR TITLE
docs: Fix simple typo, enpoint -> endpoint

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -48,6 +48,6 @@ Configuration
 
 - **REST_USE_JWT** - Enable JWT Authentication instead of Token/Session based. This is built on top of django-rest-framework-jwt http://getblimp.github.io/django-rest-framework-jwt/, which must also be installed. (default: False)
 
-- **OLD_PASSWORD_FIELD_ENABLED** - set it to True if you want to have old password verification on password change enpoint (default: False)
+- **OLD_PASSWORD_FIELD_ENABLED** - set it to True if you want to have old password verification on password change endpoint (default: False)
 
 - **LOGOUT_ON_PASSWORD_CHANGE** - set to False if you want to keep the current user logged in after a password change


### PR DESCRIPTION
There is a small typo in docs/configuration.rst.

Should read `endpoint` rather than `enpoint`.

