### PR TITLE
fix(registration): password2 isn't required if ACCOUNT_SIGNUP_PASSWORD_ENTER_TWICE is False

### DIFF
--- a/rest_auth/registration/serializers.py
+++ b/rest_auth/registration/serializers.py
@@ -171,7 +171,10 @@ class RegisterSerializer(serializers.Serializer):
     )
     email = serializers.EmailField(required=allauth_settings.EMAIL_REQUIRED)
     password1 = serializers.CharField(write_only=True)
-    password2 = serializers.CharField(write_only=True)
+    password2 = serializers.CharField(
+        write_only=True,
+        required=allauth_settings.SIGNUP_PASSWORD_ENTER_TWICE
+    )
 
     def validate_username(self, username):
         username = get_adapter().clean_username(username)
@@ -189,9 +192,10 @@ class RegisterSerializer(serializers.Serializer):
         return get_adapter().clean_password(password)
 
     def validate(self, data):
-        if data['password1'] != data['password2']:
+        if not allauth_settings.SIGNUP_PASSWORD_ENTER_TWICE:
+            return data
+        elif data['password1'] != data['password2']:
             raise serializers.ValidationError(_("The two password fields didn't match."))
-        return data
 
     def custom_signup(self, request, user):
         pass


### PR DESCRIPTION
This field has always been required