### PR TITLE
Removed use of deprecated method

### DIFF
--- a/rest_auth/serializers.py
+++ b/rest_auth/serializers.py
@@ -4,7 +4,7 @@ from django.contrib.auth.forms import PasswordResetForm, SetPasswordForm
 from django.contrib.auth.tokens import default_token_generator
 from django.utils.http import urlsafe_base64_decode as uid_decoder
 from django.utils.translation import ugettext_lazy as _
-from django.utils.encoding import force_text
+from django.utils.encoding import force_string
 
 from rest_framework import serializers, exceptions
 from rest_framework.exceptions import ValidationError
@@ -205,7 +205,7 @@ class PasswordResetConfirmSerializer(serializers.Serializer):
 
         # Decode the uidb64 to uid to get User object
         try:
-            uid = force_text(uid_decoder(attrs['uid']))
+            uid = force_str(uid_decoder(attrs['uid']))
             self.user = UserModel._default_manager.get(pk=uid)
         except (TypeError, ValueError, OverflowError, UserModel.DoesNotExist):
             raise ValidationError({'uid': ['Invalid value']})


### PR DESCRIPTION
Version 3.0 of Django made `force_text` deprecated. `force_text` is just an alias for `force_str`, which isn't deprecated, so I swapped it out.

https://docs.djangoproject.com/en/3.0/ref/utils/#django.utils.encoding.force_text