### PR TITLE
fix import errors for django v.4.0

### DIFF
--- a/demo/demo/urls.py
+++ b/demo/demo/urls.py
@@ -1,44 +1,44 @@
-from django.conf.urls import include, url
+from django.urls import include, re_path
 from django.contrib import admin
 from django.views.generic import TemplateView, RedirectView
 
 from rest_framework_swagger.views import get_swagger_view
 
 urlpatterns = [
-    url(r'^$', TemplateView.as_view(template_name="home.html"), name='home'),
-    url(r'^signup/$', TemplateView.as_view(template_name="signup.html"),
+    re_path(r'^$', TemplateView.as_view(template_name="home.html"), name='home'),
+    re_path(r'^signup/$', TemplateView.as_view(template_name="signup.html"),
         name='signup'),
-    url(r'^email-verification/$',
+    re_path(r'^email-verification/$',
         TemplateView.as_view(template_name="email_verification.html"),
         name='email-verification'),
-    url(r'^login/$', TemplateView.as_view(template_name="login.html"),
+    re_path(r'^login/$', TemplateView.as_view(template_name="login.html"),
         name='login'),
-    url(r'^logout/$', TemplateView.as_view(template_name="logout.html"),
+    re_path(r'^logout/$', TemplateView.as_view(template_name="logout.html"),
         name='logout'),
-    url(r'^password-reset/$',
+    re_path(r'^password-reset/$',
         TemplateView.as_view(template_name="password_reset.html"),
         name='password-reset'),
-    url(r'^password-reset/confirm/$',
+    re_path(r'^password-reset/confirm/$',
         TemplateView.as_view(template_name="password_reset_confirm.html"),
         name='password-reset-confirm'),
 
-    url(r'^user-details/$',
+    re_path(r'^user-details/$',
         TemplateView.as_view(template_name="user_details.html"),
         name='user-details'),
-    url(r'^password-change/$',
+    re_path(r'^password-change/$',
         TemplateView.as_view(template_name="password_change.html"),
         name='password-change'),
 
 
     # this url is used to generate email content
-    url(r'^password-reset/confirm/(?P<uidb64>[0-9A-Za-z_\-]+)/(?P<token>[0-9A-Za-z]{1,13}-[0-9A-Za-z]{1,20})/$',
+    re_path(r'^password-reset/confirm/(?P<uidb64>[0-9A-Za-z_\-]+)/(?P<token>[0-9A-Za-z]{1,13}-[0-9A-Za-z]{1,20})/$',
         TemplateView.as_view(template_name="password_reset_confirm.html"),
         name='password_reset_confirm'),
 
-    url(r'^rest-auth/', include('rest_auth.urls')),
-    url(r'^rest-auth/registration/', include('rest_auth.registration.urls')),
-    url(r'^account/', include('allauth.urls')),
-    url(r'^admin/', admin.site.urls),
-    url(r'^accounts/profile/$', RedirectView.as_view(url='/', permanent=True), name='profile-redirect'),
-    url(r'^docs/$', get_swagger_view(title='API Docs'), name='api_docs')
+    re_path(r'^rest-auth/', include('rest_auth.urls')),
+    re_path(r'^rest-auth/registration/', include('rest_auth.registration.urls')),
+    re_path(r'^account/', include('allauth.urls')),
+    re_path(r'^admin/', admin.site.urls),
+    re_path(r'^accounts/profile/$', RedirectView.as_view(url='/', permanent=True), name='profile-redirect'),
+    re_path(r'^docs/$', get_swagger_view(title='API Docs'), name='api_docs')
 ]

--- a/rest_auth/registration/serializers.py
+++ b/rest_auth/registration/serializers.py
@@ -1,5 +1,5 @@
 from django.http import HttpRequest
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.contrib.auth import get_user_model
 
 try:

--- a/rest_auth/registration/urls.py
+++ b/rest_auth/registration/urls.py
@@ -1,11 +1,11 @@
 from django.views.generic import TemplateView
-from django.conf.urls import url
+from django.urls import re_path
 
 from .views import RegisterView, VerifyEmailView
 
 urlpatterns = [
-    url(r'^$', RegisterView.as_view(), name='rest_register'),
-    url(r'^verify-email/$', VerifyEmailView.as_view(), name='rest_verify_email'),
+    re_path(r'^$', RegisterView.as_view(), name='rest_register'),
+    re_path(r'^verify-email/$', VerifyEmailView.as_view(), name='rest_verify_email'),
 
     # This url is used by django-allauth and empty TemplateView is
     # defined just to allow reverse() call inside app, for example when email
@@ -18,6 +18,6 @@ urlpatterns = [
     # If you don't want to use API on that step, then just use ConfirmEmailView
     # view from:
     # django-allauth https://github.com/pennersr/django-allauth/blob/master/allauth/account/views.py
-    url(r'^account-confirm-email/(?P<key>[-:\w]+)/$', TemplateView.as_view(),
+    re_path(r'^account-confirm-email/(?P<key>[-:\w]+)/$', TemplateView.as_view(),
         name='account_confirm_email'),
 ]

--- a/rest_auth/registration/views.py
+++ b/rest_auth/registration/views.py
@@ -1,6 +1,6 @@
 from django.conf import settings
 from django.utils.decorators import method_decorator
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.views.decorators.debug import sensitive_post_parameters
 
 from rest_framework.views import APIView

--- a/rest_auth/serializers.py
+++ b/rest_auth/serializers.py
@@ -3,8 +3,8 @@ from django.conf import settings
 from django.contrib.auth.forms import PasswordResetForm, SetPasswordForm
 from django.contrib.auth.tokens import default_token_generator
 from django.utils.http import urlsafe_base64_decode as uid_decoder
-from django.utils.translation import ugettext_lazy as _
-from django.utils.encoding import force_text
+from django.utils.translation import gettext_lazy as _
+from django.utils.encoding import force_str
 
 from rest_framework import serializers, exceptions
 from rest_framework.exceptions import ValidationError
@@ -205,7 +205,7 @@ class PasswordResetConfirmSerializer(serializers.Serializer):
 
         # Decode the uidb64 to uid to get User object
         try:
-            uid = force_text(uid_decoder(attrs['uid']))
+            uid = force_str(uid_decoder(attrs['uid']))
             self.user = UserModel._default_manager.get(pk=uid)
         except (TypeError, ValueError, OverflowError, UserModel.DoesNotExist):
             raise ValidationError({'uid': ['Invalid value']})

--- a/rest_auth/tests/django_urls.py
+++ b/rest_auth/tests/django_urls.py
@@ -1,6 +1,6 @@
 # Moved in Django 1.8 from django to tests/auth_tests/urls.py
 
-from django.conf.urls import url
+from django.urls import re_path
 from django.contrib.auth import views
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.urls import urlpatterns
@@ -8,23 +8,23 @@ from django.contrib.auth.urls import urlpatterns
 
 # special urls for auth test cases
 urlpatterns += [
-    url(r'^logout/custom_query/$', views.logout, dict(redirect_field_name='follow')),
-    url(r'^logout/next_page/$', views.logout, dict(next_page='/somewhere/')),
-    url(r'^logout/next_page/named/$', views.logout, dict(next_page='password_reset')),
-    url(r'^password_reset_from_email/$', views.password_reset, dict(from_email='staffmember@example.com')),
-    url(r'^password_reset/custom_redirect/$', views.password_reset, dict(post_reset_redirect='/custom/')),
-    url(r'^password_reset/custom_redirect/named/$', views.password_reset, dict(post_reset_redirect='password_reset')),
-    url(r'^password_reset/html_email_template/$', views.password_reset,
+    re_path(r'^logout/custom_query/$', views.logout, dict(redirect_field_name='follow')),
+    re_path(r'^logout/next_page/$', views.logout, dict(next_page='/somewhere/')),
+    re_path(r'^logout/next_page/named/$', views.logout, dict(next_page='password_reset')),
+    re_path(r'^password_reset_from_email/$', views.password_reset, dict(from_email='staffmember@example.com')),
+    re_path(r'^password_reset/custom_redirect/$', views.password_reset, dict(post_reset_redirect='/custom/')),
+    re_path(r'^password_reset/custom_redirect/named/$', views.password_reset, dict(post_reset_redirect='password_reset')),
+    re_path(r'^password_reset/html_email_template/$', views.password_reset,
         dict(html_email_template_name='registration/html_password_reset_email.html')),
-    url(r'^reset/custom/(?P<uidb64>[0-9A-Za-z_\-]+)/(?P<token>[0-9A-Za-z]{1,13}-[0-9A-Za-z]{1,20})/$',
+    re_path(r'^reset/custom/(?P<uidb64>[0-9A-Za-z_\-]+)/(?P<token>[0-9A-Za-z]{1,13}-[0-9A-Za-z]{1,20})/$',
         views.password_reset_confirm,
         dict(post_reset_redirect='/custom/')),
-    url(r'^reset/custom/named/(?P<uidb64>[0-9A-Za-z_\-]+)/(?P<token>[0-9A-Za-z]{1,13}-[0-9A-Za-z]{1,20})/$',
+    re_path(r'^reset/custom/named/(?P<uidb64>[0-9A-Za-z_\-]+)/(?P<token>[0-9A-Za-z]{1,13}-[0-9A-Za-z]{1,20})/$',
         views.password_reset_confirm,
         dict(post_reset_redirect='password_reset')),
-    url(r'^password_change/custom/$', views.password_change, dict(post_change_redirect='/custom/')),
-    url(r'^password_change/custom/named/$', views.password_change, dict(post_change_redirect='password_reset')),
-    url(r'^admin_password_reset/$', views.password_reset, dict(is_admin_site=True)),
-    url(r'^login_required/$', login_required(views.password_reset)),
-    url(r'^login_required_login_url/$', login_required(views.password_reset, login_url='/somewhere/')),
+    re_path(r'^password_change/custom/$', views.password_change, dict(post_change_redirect='/custom/')),
+    re_path(r'^password_change/custom/named/$', views.password_change, dict(post_change_redirect='password_reset')),
+    re_path(r'^admin_password_reset/$', views.password_reset, dict(is_admin_site=True)),
+    re_path(r'^login_required/$', login_required(views.password_reset)),
+    re_path(r'^login_required_login_url/$', login_required(views.password_reset, login_url='/somewhere/')),
 ]

--- a/rest_auth/tests/mixins.py
+++ b/rest_auth/tests/mixins.py
@@ -2,7 +2,7 @@ import json
 
 from django.conf import settings
 from django.test.client import Client, MULTIPART_CONTENT
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 
 from rest_framework import status
 from rest_framework import permissions
@@ -59,7 +59,7 @@ class TestsMixin(object):
 
         self.response.json = {}
         if is_json and self.response.content:
-            self.response.json = json.loads(force_text(self.response.content))
+            self.response.json = json.loads(force_str(self.response.content))
 
         if status_code:
             self.assertEqual(self.response.status_code, status_code)

--- a/rest_auth/tests/test_api.py
+++ b/rest_auth/tests/test_api.py
@@ -2,7 +2,7 @@ from django.test import TestCase, override_settings
 from django.contrib.auth import get_user_model
 from django.core import mail
 from django.conf import settings
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 
 from allauth.account import app_settings as account_app_settings
 from rest_framework import status
@@ -300,7 +300,7 @@ class APIBasicTests(TestsMixin, TestCase):
         data = {
             'new_password1': self.NEW_PASS,
             'new_password2': self.NEW_PASS,
-            'uid': force_text(url_kwargs['uid']),
+            'uid': force_str(url_kwargs['uid']),
             'token': '-wrong-token-'
         }
         self.post(url, data=data, status_code=400)
@@ -327,7 +327,7 @@ class APIBasicTests(TestsMixin, TestCase):
         data = {
             'new_password1': self.NEW_PASS,
             'new_password2': self.NEW_PASS,
-            'uid': force_text(url_kwargs['uid']),
+            'uid': force_str(url_kwargs['uid']),
             'token': url_kwargs['token']
         }
         url = reverse('rest_password_reset_confirm')

--- a/rest_auth/tests/urls.py
+++ b/rest_auth/tests/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import url, include
+from django.urls import re_path, include
 from django.views.generic import TemplateView
 from . import django_urls
 
@@ -53,20 +53,20 @@ class TwitterLoginNoAdapter(SocialLoginView):
 
 
 urlpatterns += [
-    url(r'^rest-registration/', include('rest_auth.registration.urls')),
-    url(r'^test-admin/', include(django_urls)),
-    url(r'^account-email-verification-sent/$', TemplateView.as_view(),
+    re_path(r'^rest-registration/', include('rest_auth.registration.urls')),
+    re_path(r'^test-admin/', include(django_urls)),
+    re_path(r'^account-email-verification-sent/$', TemplateView.as_view(),
         name='account_email_verification_sent'),
-    url(r'^account-confirm-email/(?P<key>[-:\w]+)/$', TemplateView.as_view(),
+    re_path(r'^account-confirm-email/(?P<key>[-:\w]+)/$', TemplateView.as_view(),
         name='account_confirm_email'),
-    url(r'^social-login/facebook/$', FacebookLogin.as_view(), name='fb_login'),
-    url(r'^social-login/twitter/$', TwitterLogin.as_view(), name='tw_login'),
-    url(r'^social-login/twitter-no-view/$', twitter_login_view, name='tw_login_no_view'),
-    url(r'^social-login/twitter-no-adapter/$', TwitterLoginNoAdapter.as_view(), name='tw_login_no_adapter'),
-    url(r'^social-login/facebook/connect/$', FacebookConnect.as_view(), name='fb_connect'),
-    url(r'^social-login/twitter/connect/$', TwitterConnect.as_view(), name='tw_connect'),
-    url(r'^socialaccounts/$', SocialAccountListView.as_view(), name='social_account_list'),
-    url(r'^socialaccounts/(?P<pk>\d+)/disconnect/$', SocialAccountDisconnectView.as_view(),
+    re_path(r'^social-login/facebook/$', FacebookLogin.as_view(), name='fb_login'),
+    re_path(r'^social-login/twitter/$', TwitterLogin.as_view(), name='tw_login'),
+    re_path(r'^social-login/twitter-no-view/$', twitter_login_view, name='tw_login_no_view'),
+    re_path(r'^social-login/twitter-no-adapter/$', TwitterLoginNoAdapter.as_view(), name='tw_login_no_adapter'),
+    re_path(r'^social-login/facebook/connect/$', FacebookConnect.as_view(), name='fb_connect'),
+    re_path(r'^social-login/twitter/connect/$', TwitterConnect.as_view(), name='tw_connect'),
+    re_path(r'^socialaccounts/$', SocialAccountListView.as_view(), name='social_account_list'),
+    re_path(r'^socialaccounts/(?P<pk>\d+)/disconnect/$', SocialAccountDisconnectView.as_view(),
         name='social_account_disconnect'),
-    url(r'^accounts/', include('allauth.socialaccount.urls'))
+    re_path(r'^accounts/', include('allauth.socialaccount.urls'))
 ]

--- a/rest_auth/urls.py
+++ b/rest_auth/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import url
+from django.urls import re_path
 
 from rest_auth.views import (
     LoginView, LogoutView, UserDetailsView, PasswordChangeView,
@@ -7,14 +7,14 @@ from rest_auth.views import (
 
 urlpatterns = [
     # URLs that do not require a session or valid token
-    url(r'^password/reset/$', PasswordResetView.as_view(),
+    re_path(r'^password/reset/$', PasswordResetView.as_view(),
         name='rest_password_reset'),
-    url(r'^password/reset/confirm/$', PasswordResetConfirmView.as_view(),
+    re_path(r'^password/reset/confirm/$', PasswordResetConfirmView.as_view(),
         name='rest_password_reset_confirm'),
-    url(r'^login/$', LoginView.as_view(), name='rest_login'),
+    re_path(r'^login/$', LoginView.as_view(), name='rest_login'),
     # URLs that require a user to be logged in with a valid session / token.
-    url(r'^logout/$', LogoutView.as_view(), name='rest_logout'),
-    url(r'^user/$', UserDetailsView.as_view(), name='rest_user_details'),
-    url(r'^password/change/$', PasswordChangeView.as_view(),
+    re_path(r'^logout/$', LogoutView.as_view(), name='rest_logout'),
+    re_path(r'^user/$', UserDetailsView.as_view(), name='rest_user_details'),
+    re_path(r'^password/change/$', PasswordChangeView.as_view(),
         name='rest_password_change'),
 ]

--- a/rest_auth/views.py
+++ b/rest_auth/views.py
@@ -6,7 +6,7 @@ from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.core.exceptions import ObjectDoesNotExist
 from django.utils.decorators import method_decorator
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.views.decorators.debug import sensitive_post_parameters
 
 from rest_framework import status


### PR DESCRIPTION
### Fix import errors:

**django.utils.translation**

- ugettext_lazy -> gettext_lazy

**django.conf.urls -> django.urls**

- url -> re_path

**django.utils.encoding**

- force_text -> force_str