### PR TITLE
Updated project to Django 5.0.2 and made necessary changes to accommo…

### DIFF
--- a/rest_auth/registration/serializers.py
+++ b/rest_auth/registration/serializers.py
@@ -1,5 +1,5 @@
 from django.http import HttpRequest
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.contrib.auth import get_user_model
 
 try:

--- a/rest_auth/registration/views.py
+++ b/rest_auth/registration/views.py
@@ -1,6 +1,6 @@
 from django.conf import settings
 from django.utils.decorators import method_decorator
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.views.decorators.debug import sensitive_post_parameters
 
 from rest_framework.views import APIView

--- a/rest_auth/serializers.py
+++ b/rest_auth/serializers.py
@@ -3,8 +3,8 @@ from django.conf import settings
 from django.contrib.auth.forms import PasswordResetForm, SetPasswordForm
 from django.contrib.auth.tokens import default_token_generator
 from django.utils.http import urlsafe_base64_decode as uid_decoder
-from django.utils.translation import ugettext_lazy as _
-from django.utils.encoding import force_text
+from django.utils.translation import gettext_lazy as _
+from django.utils.encoding import  force_str 
 
 from rest_framework import serializers, exceptions
 from rest_framework.exceptions import ValidationError

--- a/rest_auth/tests/mixins.py
+++ b/rest_auth/tests/mixins.py
@@ -2,7 +2,7 @@ import json
 
 from django.conf import settings
 from django.test.client import Client, MULTIPART_CONTENT
-from django.utils.encoding import force_text
+from django.utils.encoding import  force_str 
 
 from rest_framework import status
 from rest_framework import permissions

--- a/rest_auth/tests/test_api.py
+++ b/rest_auth/tests/test_api.py
@@ -2,7 +2,7 @@ from django.test import TestCase, override_settings
 from django.contrib.auth import get_user_model
 from django.core import mail
 from django.conf import settings
-from django.utils.encoding import force_text
+from django.utils.encoding import  force_str 
 
 from allauth.account import app_settings as account_app_settings
 from rest_framework import status

--- a/rest_auth/urls.py
+++ b/rest_auth/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import url
+from django.urls import path
 
 from rest_auth.views import (
     LoginView, LogoutView, UserDetailsView, PasswordChangeView,
@@ -7,14 +7,14 @@ from rest_auth.views import (
 
 urlpatterns = [
     # URLs that do not require a session or valid token
-    url(r'^password/reset/$', PasswordResetView.as_view(),
+    path('password/reset/', PasswordResetView.as_view(),
         name='rest_password_reset'),
-    url(r'^password/reset/confirm/$', PasswordResetConfirmView.as_view(),
+    path('password/reset/confirm/', PasswordResetConfirmView.as_view(),
         name='rest_password_reset_confirm'),
-    url(r'^login/$', LoginView.as_view(), name='rest_login'),
+    path('login/', LoginView.as_view(), name='rest_login'),
     # URLs that require a user to be logged in with a valid session / token.
-    url(r'^logout/$', LogoutView.as_view(), name='rest_logout'),
-    url(r'^user/$', UserDetailsView.as_view(), name='rest_user_details'),
-    url(r'^password/change/$', PasswordChangeView.as_view(),
+    path('logout/', LogoutView.as_view(), name='rest_logout'),
+    path('user/', UserDetailsView.as_view(), name='rest_user_details'),
+    path('password/change/', PasswordChangeView.as_view(),
         name='rest_password_change'),
 ]

--- a/rest_auth/views.py
+++ b/rest_auth/views.py
@@ -6,7 +6,7 @@ from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.core.exceptions import ObjectDoesNotExist
 from django.utils.decorators import method_decorator
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.views.decorators.debug import sensitive_post_parameters
 
 from rest_framework import status


### PR DESCRIPTION
This pull request aims to make the Django REST Auth project compatible with Django 5.0.2 and includes some other updates. The changes I've made are as follows:

- Updated the code to make it compatible with Django 5.0.2 by adjusting for removed methods.
- Added the `force_str` method to the `rest_auth\serializers.py` file.
- Added the `gettext_lazy` method to the `views.py` file.
- Replaced `url` functions with `path` functions in the `urlpatterns` list.

These changes ensure that the project is compatible with the latest Django version and enhances project stability by adjusting for removed methods.

I kindly request a review of this pull request and integration into the project's main branch. Thank you.
